### PR TITLE
feat: Add ReadTheDocs compatibility with Sphinx documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,35 @@
+# ReadTheDocs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  builder: html
+  fail_on_warning: false
+
+# Install Python dependencies
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+# Optional: enable PDF generation
+formats:
+  - pdf
+  - epub
+
+# Optional: enable search
+search:
+  ranking:
+    api-reference.html: 1
+  ignore:
+    - 404.html 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ settings = LoggingSettings(
 logger = configure_logging(settings=settings)
 ```
 
-📖 **For complete configuration reference, see [Configuration Guide](docs/config.md)**
+📖 **For complete configuration reference, see [Configuration Guide](https://fapilog.readthedocs.io/en/latest/config.html) or [docs/config.md](docs/config.md)**
 
 ---
 
@@ -167,6 +167,7 @@ logger = configure_logging(settings=settings)
 - [🚀 Quick Start](#-quick-start)
 - [📖 Documentation](#-documentation)
   - [Quick Configuration Reference](#quick-configuration-reference)
+  - [📚 ReadTheDocs](https://fapilog.readthedocs.io/) - Complete documentation with search
   - [Configuration Guide](docs/config.md)
   - [API Reference](docs/api-reference.md)
   - [User Guide](docs/user-guide.md)

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -1,0 +1,273 @@
+API Reference
+=============
+
+This document provides a complete reference for all public APIs in ``fapilog``. The API is designed to be simple for basic usage while remaining fully extensible for advanced scenarios.
+
+Table of Contents
+-----------------
+
+* `Core Functions`_
+* `Configuration`_
+* `Logging Interface`_
+* `Middleware`_
+* `Trace Propagation`_
+* `Enrichers`_
+* `Sinks`_
+* `Metrics and Monitoring`_
+* `Context Management`_
+* `Types and Models`_
+
+Core Functions
+==============
+
+configure_logging()
+-------------------
+
+The primary function for setting up structured logging in your application.
+
+.. code-block:: python
+
+   from fapilog import configure_logging
+
+   # Basic usage with defaults
+   configure_logging()
+
+   # With FastAPI app (automatically adds middleware)
+   from fastapi import FastAPI
+   app = FastAPI()
+   configure_logging(app=app)
+
+   # With custom settings
+   from fapilog.settings import LoggingSettings
+   settings = LoggingSettings(level="DEBUG", queue_enabled=True)
+   configure_logging(settings=settings)
+
+**Parameters:**
+
+- ``settings`` (LoggingSettings, optional): Complete configuration object. If ``None``, created from environment variables.
+- ``app`` (Any, optional): FastAPI app instance. If provided, ``TraceIDMiddleware`` is automatically registered.
+
+**Returns:**
+
+- ``structlog.BoundLogger``: Configured logger instance
+
+**Raises:**
+
+- ``RuntimeError``: If called from an async context without proper setup
+
+.. note::
+   This function is idempotent - subsequent calls will not duplicate handlers. When ``app`` is provided, middleware is registered and shutdown handlers are configured. Environment variables with ``FAPILOG_`` prefix are automatically loaded.
+
+get_current_trace_id()
+----------------------
+
+Access the current trace ID from within a request context.
+
+.. code-block:: python
+
+   from fapilog import get_current_trace_id
+
+   @app.get("/api/status")
+   async def get_status():
+       trace_id = get_current_trace_id()
+
+       if trace_id:
+           log.info("Status check requested", trace_id=trace_id)
+           return {"status": "ok", "trace_id": trace_id}
+       else:
+           log.info("Status check outside request context")
+           return {"status": "ok", "trace_id": None}
+
+**Returns:**
+
+- ``str | None``: Current trace ID if within a request context, ``None`` otherwise
+
+**Use Cases:**
+
+- Business logic that needs to include trace ID in responses
+- Custom error handling with trace correlation
+- Integration with external services requiring trace headers
+- Audit logging with request correlation
+
+.. note::
+   Only available within request context (when using ``TraceIDMiddleware``). Returns ``None`` when called outside of a request (e.g., startup, background tasks). The trace ID is either extracted from incoming headers or auto-generated. Thread-safe and async-safe via ``contextvars``.
+
+Configuration
+=============
+
+LoggingSettings
+---------------
+
+Configuration class for all logging settings. Can be configured via environment variables or programmatically.
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+
+   settings = LoggingSettings(
+       level="INFO",
+       sinks=["stdout", "file:///var/log/app.log"],
+       queue_enabled=True,
+       redact_patterns=["password", "token"]
+   )
+
+**Key Configuration Options:**
+
+- ``level``: Log level (DEBUG, INFO, WARN, ERROR, CRITICAL)
+- ``sinks``: List of output destinations
+- ``queue_enabled``: Enable async logging queue
+- ``redact_patterns``: Patterns to redact from logs
+- ``json_console``: Console output format (auto, json, pretty)
+
+For complete configuration reference, see :doc:`config`.
+
+Logging Interface
+=================
+
+The main logging interface provided by ``fapilog``.
+
+.. code-block:: python
+
+   from fapilog import log
+
+   # Basic logging
+   log.info("User logged in", user_id=123)
+   log.error("Database error", error=str(e), table="users")
+   
+   # With structured data
+   log.info("Request processed", 
+            method="GET", 
+            path="/api/users", 
+            status_code=200,
+            duration_ms=45)
+
+**Log Levels:**
+
+- ``log.debug()``: Detailed information for debugging
+- ``log.info()``: General information messages
+- ``log.warning()`` / ``log.warn()``: Warning messages
+- ``log.error()``: Error messages
+- ``log.critical()``: Critical error messages
+
+Middleware
+==========
+
+TraceIDMiddleware
+-----------------
+
+FastAPI middleware for automatic trace ID injection and request context enrichment.
+
+.. code-block:: python
+
+   from fastapi import FastAPI
+   from fapilog.middleware import TraceIDMiddleware
+
+   app = FastAPI()
+   
+   # Manual registration
+   app.add_middleware(TraceIDMiddleware)
+   
+   # Or use configure_logging() with app parameter
+   from fapilog import configure_logging
+   configure_logging(app=app)  # Automatically adds middleware
+
+**Features:**
+
+- Automatic trace ID generation and propagation
+- Request timing and status code logging
+- Context variable management
+- Request/response logging
+
+Trace Propagation
+=================
+
+Functions for working with distributed tracing.
+
+.. code-block:: python
+
+   from fapilog import get_current_trace_id, get_trace_headers
+
+   # Get current trace ID
+   trace_id = get_current_trace_id()
+   
+   # Get headers for downstream requests
+   headers = get_trace_headers()
+   response = httpx.get("https://api.example.com", headers=headers)
+
+Enrichers
+=========
+
+Custom enrichers for adding contextual information to logs.
+
+.. code-block:: python
+
+   from fapilog.enrichers import RequestEnricher, ResourceEnricher
+   
+   # Built-in enrichers are automatically configured
+   # Custom enrichers can be added via settings
+
+Sinks
+=====
+
+Output destinations for log messages.
+
+**Built-in Sinks:**
+
+- ``stdout``: Console output
+- ``file://path/to/file.log``: File output with rotation
+- ``loki://host:port``: Grafana Loki integration
+
+.. code-block:: python
+
+   # Configure multiple sinks
+   settings = LoggingSettings(
+       sinks=[
+           "stdout",
+           "file:///var/log/app.log",
+           "loki://loki:3100"
+       ]
+   )
+
+Metrics and Monitoring
+======================
+
+Performance and health metrics integration.
+
+.. code-block:: python
+
+   from fapilog.monitoring import get_queue_metrics
+   
+   # Get current queue status
+   metrics = get_queue_metrics()
+   print(f"Queue size: {metrics.current_size}")
+   print(f"Total processed: {metrics.total_processed}")
+
+Context Management
+==================
+
+Functions for managing request and user context.
+
+.. code-block:: python
+
+   from fapilog import set_user_context, get_user_context
+   
+   # Set user context
+   set_user_context(user_id="123", username="alice")
+   
+   # Context is automatically included in logs
+   log.info("Action performed")  # Includes user_id and username
+
+Types and Models
+================
+
+Core data types and Pydantic models used by ``fapilog``.
+
+**Key Types:**
+
+- ``LogLevel``: Enumeration of log levels
+- ``SinkConfig``: Configuration for output sinks
+- ``QueueConfig``: Async queue configuration
+- ``RedactionConfig``: PII redaction settings
+
+.. note::
+   For complete API documentation with all functions, classes, and parameters, see the full API reference in the source markdown file: ``docs/api-reference.md`` 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,151 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../src"))
+
+project = "fapilog"
+copyright = "2024, Chris Haste"
+author = "Chris Haste"
+release = "0.1.2"
+version = "0.1.2"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "myst_parser",  # For markdown support
+]
+
+templates_path = ["_templates"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "*.md",  # Exclude all markdown files to avoid conflicts
+    "stories/*",  # Exclude story files
+    "REVIEW.md",
+    "api-reference.md",
+    "user-guide.md",
+    "config.md",
+    "container-architecture.md",
+    "error-handling-implementation-summary.md",
+    "story-13-refactored-summary.md",
+    "architecture-improvements-summary.md",
+    "epics.md",
+    "documentation-structure.md",
+    "prd-phase-1-mvp.md",
+    "sprint-planning-weeks-1-4.md",
+]
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+
+# -- Extension configuration -------------------------------------------------
+
+# Napoleon settings for Google/NumPy style docstrings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
+
+# Autodoc settings
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
+}
+
+# Intersphinx mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "fastapi": ("https://fastapi.tiangolo.com", None),
+    "structlog": ("https://www.structlog.org/en/stable/", None),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
+}
+
+# MyST parser settings for markdown support
+myst_enable_extensions = [
+    "deflist",
+    "tasklist",
+    "colon_fence",
+    "fieldlist",
+    "attrs_inline",
+]
+
+# TODO extension
+todo_include_todos = True
+
+# HTML theme options
+html_theme_options = {
+    "canonical_url": "",
+    "analytics_id": "",
+    "logo_only": False,
+    "display_version": True,
+    "prev_next_buttons_location": "bottom",
+    "style_external_links": False,
+    "vcs_pageview_mode": "",
+    "style_nav_header_background": "#2980B9",
+    # TOC options
+    "collapse_navigation": False,
+    "sticky_navigation": True,
+    "navigation_depth": 4,
+    "includehidden": True,
+    "titles_only": False,
+}
+
+# Custom sidebar
+html_sidebars = {
+    "**": [
+        "about.html",
+        "navigation.html",
+        "relations.html",
+        "searchbox.html",
+        "donate.html",
+    ]
+}
+
+# Additional HTML context
+html_context = {
+    "display_github": True,
+    "github_user": "chris-haste",
+    "github_repo": "fastapi-logger",
+    "github_version": "main",
+    "conf_py_path": "/docs/",
+}
+
+# Master document (index page)
+master_doc = "index"
+
+# Source file extensions
+source_suffix = {
+    ".rst": None,
+}

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,525 @@
+Configuration Guide
+===================
+
+This guide provides a complete reference for all configuration options available in ``fapilog``. All settings can be configured via environment variables or programmatically through the ``LoggingSettings`` class.
+
+Quick Start
+-----------
+
+The simplest way to configure ``fapilog`` is through environment variables:
+
+.. code-block:: bash
+
+   # Basic configuration
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout
+   export FAPILOG_JSON_CONSOLE=auto
+
+   # Start your application
+   python your_app.py
+
+Or programmatically:
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+   from fapilog import configure_logging
+
+   settings = LoggingSettings(
+       level="INFO",
+       sinks=["stdout"],
+       json_console="auto"
+   )
+   logger = configure_logging(settings=settings)
+
+Configuration Reference
+=======================
+
+Core Logging Settings
+---------------------
+
+.. _log_level:
+
+level
+~~~~~
+
+:Type: ``str``
+:Default: ``"INFO"``
+:Environment Variable: ``FAPILOG_LEVEL``
+:Valid Values: ``"DEBUG"``, ``"INFO"``, ``"WARN"``, ``"WARNING"``, ``"ERROR"``, ``"CRITICAL"``
+
+Controls the minimum log level for output. Only messages at or above this level will be logged.
+
+.. code-block:: bash
+
+   # Set to debug for development
+   export FAPILOG_LEVEL=DEBUG
+
+   # Set to warning for production
+   export FAPILOG_LEVEL=WARNING
+
+.. _sinks:
+
+sinks
+~~~~~
+
+:Type: ``Union[List[str], str]``
+:Default: ``["stdout"]``
+:Environment Variable: ``FAPILOG_SINKS``
+:Valid Values: ``"stdout"``, ``"file://path/to/file.log"``, ``"loki://host:port"``
+
+Comma-separated list of sink destinations for log output. Supports multiple sinks for redundancy.
+
+.. code-block:: bash
+
+   # Single sink
+   export FAPILOG_SINKS=stdout
+
+   # Multiple sinks
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log
+
+   # With Loki
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log,loki://loki:3100
+
+.. _json_console:
+
+json_console
+~~~~~~~~~~~~
+
+:Type: ``str``
+:Default: ``"auto"``
+:Environment Variable: ``FAPILOG_JSON_CONSOLE``
+:Valid Values: ``"auto"``, ``"json"``, ``"pretty"``
+
+Controls the output format for console (stdout) logs.
+
+- **auto**: Automatically chooses based on TTY detection (pretty in terminals, JSON otherwise)
+- **json**: Always output JSON format (one line per event)
+- **pretty**: Always output pretty format (colorized, multi-line)
+
+.. code-block:: bash
+
+   # Force JSON output
+   export FAPILOG_JSON_CONSOLE=json
+
+   # Force pretty output
+   export FAPILOG_JSON_CONSOLE=pretty
+
+   # Auto-detect (default)
+   export FAPILOG_JSON_CONSOLE=auto
+
+.. _sampling_rate:
+
+sampling_rate
+~~~~~~~~~~~~~
+
+:Type: ``float``
+:Default: ``1.0``
+:Environment Variable: ``FAPILOG_SAMPLING_RATE``
+:Valid Range: ``0.0`` to ``1.0``
+
+Controls the percentage of log messages to process. Useful for high-volume logging scenarios.
+
+.. code-block:: bash
+
+   # Log 50% of messages
+   export FAPILOG_SAMPLING_RATE=0.5
+
+   # Log all messages (default)
+   export FAPILOG_SAMPLING_RATE=1.0
+
+Redaction Settings
+------------------
+
+.. _redact_patterns:
+
+redact_patterns
+~~~~~~~~~~~~~~~
+
+:Type: ``Union[List[str], str]``
+:Default: ``[]``
+:Environment Variable: ``FAPILOG_REDACT_PATTERNS``
+
+Comma-separated list of regex patterns to redact from log messages. Useful for masking sensitive data.
+
+.. code-block:: bash
+
+   # Redact passwords and tokens
+   export FAPILOG_REDACT_PATTERNS=password,token,secret
+
+   # Multiple patterns
+   export FAPILOG_REDACT_PATTERNS=password,token,secret,api_key
+
+.. _redact_fields:
+
+redact_fields
+~~~~~~~~~~~~~
+
+:Type: ``Union[List[str], str]``
+:Default: ``[]``
+:Environment Variable: ``FAPILOG_REDACT_FIELDS``
+
+Comma-separated list of field names to redact from log messages. Supports dot notation for nested fields.
+
+.. code-block:: bash
+
+   # Redact specific fields
+   export FAPILOG_REDACT_FIELDS=user.password,request.headers.authorization
+
+   # Multiple fields
+   export FAPILOG_REDACT_FIELDS=password,api_key,secret_token
+
+.. _redact_replacement:
+
+redact_replacement
+~~~~~~~~~~~~~~~~~~
+
+:Type: ``str``
+:Default: ``"REDACTED"``
+:Environment Variable: ``FAPILOG_REDACT_REPLACEMENT``
+
+The replacement value used for redacted fields.
+
+.. code-block:: bash
+
+   # Custom replacement
+   export FAPILOG_REDACT_REPLACEMENT=***
+
+   # Empty replacement
+   export FAPILOG_REDACT_REPLACEMENT=
+
+.. _redact_level:
+
+redact_level
+~~~~~~~~~~~~
+
+:Type: ``str``
+:Default: ``"INFO"``
+:Environment Variable: ``FAPILOG_REDACT_LEVEL``
+:Valid Values: ``"DEBUG"``, ``"INFO"``, ``"WARN"``, ``"WARNING"``, ``"ERROR"``, ``"CRITICAL"``
+
+Minimum log level for redaction. Redaction only applies to messages at or above this level.
+
+.. code-block:: bash
+
+   # Redact in all levels
+   export FAPILOG_REDACT_LEVEL=DEBUG
+
+   # Only redact in INFO and above (default)
+   export FAPILOG_REDACT_LEVEL=INFO
+
+.. _enable_auto_redact_pii:
+
+enable_auto_redact_pii
+~~~~~~~~~~~~~~~~~~~~~~
+
+:Type: ``bool``
+:Default: ``True``
+:Environment Variable: ``FAPILOG_ENABLE_AUTO_REDACT_PII``
+
+Enables automatic PII (Personally Identifiable Information) detection and redaction.
+
+.. code-block:: bash
+
+   # Disable automatic PII redaction
+   export FAPILOG_ENABLE_AUTO_REDACT_PII=false
+
+   # Enable automatic PII redaction (default)
+   export FAPILOG_ENABLE_AUTO_REDACT_PII=true
+
+.. _custom_pii_patterns:
+
+custom_pii_patterns
+~~~~~~~~~~~~~~~~~~~
+
+:Type: ``List[str]``
+:Default: ``[]``
+:Environment Variable: ``FAPILOG_CUSTOM_PII_PATTERNS``
+
+Comma-separated list of custom regex patterns for PII detection.
+
+.. code-block:: bash
+
+   # Add custom PII patterns
+   export FAPILOG_CUSTOM_PII_PATTERNS=credit_card,ssn,phone_number
+
+Queue Settings
+--------------
+
+.. _queue_enabled:
+
+queue_enabled
+~~~~~~~~~~~~~
+
+:Type: ``bool``
+:Default: ``True``
+:Environment Variable: ``FAPILOG_QUEUE_ENABLED``
+
+Enables the async queue for non-blocking logging.
+
+.. code-block:: bash
+
+   # Disable async queue
+   export FAPILOG_QUEUE_ENABLED=false
+
+   # Enable async queue (default)
+   export FAPILOG_QUEUE_ENABLED=true
+
+.. _queue_maxsize:
+
+queue_maxsize
+~~~~~~~~~~~~~
+
+:Type: ``int``
+:Default: ``1000``
+:Environment Variable: ``FAPILOG_QUEUE_MAXSIZE``
+
+Maximum size of the async log queue.
+
+.. code-block:: bash
+
+   # Larger queue for high-volume logging
+   export FAPILOG_QUEUE_MAXSIZE=5000
+
+   # Smaller queue for memory-constrained environments
+   export FAPILOG_QUEUE_MAXSIZE=100
+
+.. _queue_overflow:
+
+queue_overflow
+~~~~~~~~~~~~~~
+
+:Type: ``Literal["drop", "block", "sample"]``
+:Default: ``"drop"``
+:Environment Variable: ``FAPILOG_QUEUE_OVERFLOW``
+
+Strategy for handling queue overflow:
+
+- **drop**: Discard new messages when queue is full
+- **block**: Wait for space in queue (may block application)
+- **sample**: Probabilistically drop messages based on sampling rate
+
+.. code-block:: bash
+
+   # Drop messages when queue is full (default)
+   export FAPILOG_QUEUE_OVERFLOW=drop
+
+   # Block until space is available
+   export FAPILOG_QUEUE_OVERFLOW=block
+
+   # Sample messages when queue is full
+   export FAPILOG_QUEUE_OVERFLOW=sample
+
+.. _queue_batch_size:
+
+queue_batch_size
+~~~~~~~~~~~~~~~~
+
+:Type: ``int``
+:Default: ``10``
+:Environment Variable: ``FAPILOG_QUEUE_BATCH_SIZE``
+
+Number of events to process in a batch.
+
+.. code-block:: bash
+
+   # Larger batches for better throughput
+   export FAPILOG_QUEUE_BATCH_SIZE=50
+
+   # Smaller batches for lower latency
+   export FAPILOG_QUEUE_BATCH_SIZE=5
+
+.. _queue_batch_timeout:
+
+queue_batch_timeout
+~~~~~~~~~~~~~~~~~~~
+
+:Type: ``float``
+:Default: ``1.0``
+:Environment Variable: ``FAPILOG_QUEUE_BATCH_TIMEOUT``
+
+Maximum time to wait for batch completion (seconds).
+
+.. code-block:: bash
+
+   # Longer timeout for slow sinks
+   export FAPILOG_QUEUE_BATCH_TIMEOUT=5.0
+
+   # Shorter timeout for real-time logging
+   export FAPILOG_QUEUE_BATCH_TIMEOUT=0.5
+
+Environment Variables vs Programmatic Configuration
+===================================================
+
+Environment Variable Approach
+-----------------------------
+
+Configure everything through environment variables:
+
+.. code-block:: bash
+
+   export FAPILOG_LEVEL=DEBUG
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log
+   export FAPILOG_QUEUE_ENABLED=true
+   export FAPILOG_REDACT_PATTERNS=password,token
+
+.. code-block:: python
+
+   from fapilog import configure_logging
+
+   # Uses environment variables automatically
+   logger = configure_logging()
+
+Programmatic Approach
+---------------------
+
+Override settings programmatically:
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+   from fapilog import configure_logging
+
+   # Override specific settings
+   settings = LoggingSettings(
+       level="DEBUG",
+       sinks=["stdout", "file:///var/log/app.log"],
+       queue_enabled=True,
+       redact_level="INFO"
+   )
+
+   logger = configure_logging(settings=settings)
+
+Mixed Configuration
+-------------------
+
+You can combine environment variables with programmatic overrides:
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+   from fapilog import configure_logging
+
+   # Start with environment defaults, then override
+   settings = LoggingSettings()
+   settings.level = "DEBUG"  # Override just the level
+   settings.sinks.append("file:///var/log/app.log")  # Add a sink
+
+   logger = configure_logging(settings=settings)
+
+Sink-Specific Configuration
+===========================
+
+File Sink
+---------
+
+File sinks support additional configuration via URI parameters:
+
+.. code-block:: bash
+
+   # Basic file logging
+   export FAPILOG_SINKS=file:///var/log/app.log
+
+   # With rotation settings
+   export FAPILOG_SINKS=file:///var/log/app.log?maxBytes=10485760&backupCount=3
+
+**File Sink Parameters:**
+
+- **maxBytes**: Maximum file size before rotation (default: 10MB)
+- **backupCount**: Number of backup files to keep (default: 5)
+
+Loki Sink
+---------
+
+Loki sinks support configuration via URI parameters:
+
+.. code-block:: bash
+
+   # Basic Loki logging
+   export FAPILOG_SINKS=loki://loki:3100
+
+   # With labels and batching
+   export FAPILOG_SINKS=loki://loki:3100?labels=app=myapi,env=prod&batch_size=50&batch_interval=1.0
+
+**Loki Sink Parameters:**
+
+- **labels**: Static labels for all log streams (e.g., ``app=myapi,env=prod``)
+- **batch_size**: Number of logs to buffer before pushing (default: 100)
+- **batch_interval**: Max seconds to wait before pushing a batch (default: 2.0)
+
+Configuration Examples
+======================
+
+Development Environment
+-----------------------
+
+.. code-block:: bash
+
+   # Development settings
+   export FAPILOG_LEVEL=DEBUG
+   export FAPILOG_SINKS=stdout
+   export FAPILOG_JSON_CONSOLE=pretty
+   export FAPILOG_QUEUE_ENABLED=true
+   export FAPILOG_REDACT_LEVEL=DEBUG
+   export FAPILOG_ENABLE_RESOURCE_METRICS=false
+
+Production Environment
+----------------------
+
+.. code-block:: bash
+
+   # Production settings
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log,loki://loki:3100
+   export FAPILOG_JSON_CONSOLE=json
+   export FAPILOG_QUEUE_ENABLED=true
+   export FAPILOG_REDACT_LEVEL=INFO
+   export FAPILOG_ENABLE_RESOURCE_METRICS=true
+   export FAPILOG_REDACT_PATTERNS=password,token,secret
+   export FAPILOG_REDACT_FIELDS=user.password,request.headers.authorization
+
+High-Volume Logging
+-------------------
+
+.. code-block:: bash
+
+   # High-volume settings
+   export FAPILOG_LEVEL=WARNING
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log
+   export FAPILOG_SAMPLING_RATE=0.1
+   export FAPILOG_QUEUE_MAXSIZE=5000
+   export FAPILOG_QUEUE_BATCH_SIZE=100
+   export FAPILOG_QUEUE_OVERFLOW=drop
+
+Security-Focused
+----------------
+
+.. code-block:: bash
+
+   # Security-focused settings
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log
+   export FAPILOG_REDACT_LEVEL=DEBUG
+   export FAPILOG_REDACT_PATTERNS=password,token,secret,api_key,ssn
+   export FAPILOG_REDACT_FIELDS=user.password,request.headers.authorization,response.body
+   export FAPILOG_ENABLE_AUTO_REDACT_PII=true
+   export FAPILOG_CUSTOM_PII_PATTERNS=credit_card,phone_number
+
+Validation
+==========
+
+All configuration values are validated when the settings are loaded. Invalid values will raise a ``ConfigurationError`` with a descriptive message:
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+
+   # This will raise ConfigurationError
+   settings = LoggingSettings(level="INVALID_LEVEL")
+
+Common validation errors:
+
+- Invalid log levels (must be one of: DEBUG, INFO, WARN, WARNING, ERROR, CRITICAL)
+- Invalid sampling rate (must be between 0.0 and 1.0)
+- Invalid queue settings (must be positive numbers)
+- Invalid sink URIs (must be valid file paths or Loki URLs) 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,332 @@
+FastAPI-Logger (``fapilog``)
+==============================
+
+.. image:: https://github.com/chris-haste/fastapi-logger/actions/workflows/ci.yml/badge.svg
+   :target: https://github.com/chris-haste/fastapi-logger/actions
+   :alt: CI
+
+.. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
+   :target: https://opensource.org/licenses/Apache-2.0
+   :alt: License
+
+.. image:: https://img.shields.io/badge/python-3.8+-blue.svg
+   :target: https://python.org
+   :alt: Python
+
+.. image:: https://img.shields.io/pypi/v/fapilog
+   :target: https://pypi.org/project/fapilog/
+   :alt: PyPI
+
+**Production-ready structured logging for FastAPI with trace IDs, async queues, and observability integration.**
+
+``fapilog`` delivers enterprise-grade logging with zero friction—JSON logs, distributed tracing, async-safe queues, and observability hooks—so every microservice in your stack emits consistent, query-friendly events from day one.
+
+.. note::
+   **Package Info**: This project is published to PyPI as ``fapilog`` and developed in the ``fastapi-logger`` repository.
+
+Why Choose fapilog?
+===================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Feature
+     - fapilog Advantage
+   * - **Zero-friction setup**
+     - One-liner ``configure_logging()``—no YAML gymnastics or copy-pasted boilerplate.
+   * - **Production-ready**
+     - Built for high-traffic microservices with async queues, distributed tracing, and observability integration.
+   * - **Structured by default**
+     - JSON logs (Docker & cloud-native friendly) with pretty console rendering for local development.
+   * - **Context propagation**
+     - Trace ID, span ID, request path, status, user ID flow through ``contextvars`` without polluting your code.
+   * - **Async & non-blocking**
+     - Background queue + worker ensures log writing never blocks the event loop, even under high RPS.
+   * - **Enterprise security**
+     - Built-in PII redaction, field-level allow/deny lists, GDPR-friendly opt-outs, and audit trails.
+   * - **Observability integration**
+     - Native OpenTelemetry spans, Prometheus/OTLP metrics, and correlation IDs across logs, traces, and metrics.
+   * - **Container architecture**
+     - Clean dependency injection with multiple configurations, thread safety, and excellent testability.
+   * - **Extensible architecture**
+     - Pluggable sinks (stdout, files, Loki, HTTP) and custom enrichers with just a few lines of code.
+   * - **Developer experience**
+     - Pytest fixtures, comprehensive examples, and detailed documentation for rapid adoption.
+
+Comparison with Alternatives
+============================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 20 20 20 15
+
+   * - Feature
+     - fapilog
+     - fastapi-logger
+     - structlog
+     - Basic logging
+   * - **Zero-config setup**
+     - ✅ One-liner
+     - ❌ Manual setup
+     - ❌ Manual setup
+     - ❌ Manual setup
+   * - **Async-safe**
+     - ✅ Background queue
+     - ❌ Blocking
+     - ❌ Blocking
+     - ❌ Blocking
+   * - **Distributed tracing**
+     - ✅ Native support
+     - ❌ Manual
+     - ❌ Manual
+     - ❌ Manual
+   * - **PII redaction**
+     - ✅ Built-in
+     - ❌ Manual
+     - ❌ Manual
+     - ❌ Manual
+   * - **Observability hooks**
+     - ✅ OpenTelemetry
+     - ❌ None
+     - ❌ None
+     - ❌ None
+   * - **Container architecture**
+     - ✅ Dependency injection
+     - ❌ Global state
+     - ❌ Global state
+     - ❌ Global state
+   * - **Multiple configs**
+     - ✅ Isolated containers
+     - ❌ Single config
+     - ❌ Single config
+     - ❌ Single config
+   * - **Production-ready**
+     - ✅ Enterprise features
+     - ⚠️ Basic
+     - ⚠️ Basic
+     - ❌ Basic
+   * - **FastAPI integration**
+     - ✅ Native middleware
+     - ✅ Native
+     - ❌ Manual
+     - ❌ Manual
+
+Quick Start
+===========
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install fapilog
+
+For additional features, install optional dependencies:
+
+.. code-block:: bash
+
+   # With Loki support
+   pip install fapilog[loki]
+
+   # With FastAPI integration helpers
+   pip install fapilog[fastapi]
+
+   # With system metrics support
+   pip install fapilog[metrics]
+
+   # For development
+   pip install fapilog[dev]
+
+Version Pinning
+~~~~~~~~~~~~~~~
+
+For production deployments, we recommend pinning the version to ensure reproducible builds:
+
+.. code-block:: bash
+
+   # Production (allows patch updates)
+   pip install fapilog~=0.1.0
+
+   # Strict reproducibility (exact version)
+   pip install fapilog==0.1.0
+
+Python Compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+``fapilog`` requires Python 3.8 or higher and is compatible with Python 3.8, 3.9, 3.10, 3.11, and 3.12.
+
+Basic Usage
+-----------
+
+After installation, you can start logging immediately:
+
+.. code-block:: python
+
+   from fapilog import configure_logging, log
+
+   configure_logging()
+   log.info("Hello from fapilog!")
+
+FastAPI Integration
+-------------------
+
+.. code-block:: python
+
+   # main.py
+   from fastapi import FastAPI
+   from fapilog import configure_logging, log
+
+   configure_logging()              # instant logging superpowers
+
+   app = FastAPI()
+
+   @app.get("/ping")
+   async def ping():
+       log.info("ping_hit")         # JSON log with trace_id, path, method, etc.
+       return {"pong": True}
+
+Run the service:
+
+.. code-block:: bash
+
+   uvicorn app.main:app --reload
+
+Local console shows colourised logs; in production the same call emits compact JSON suitable for Loki, Cloud Logging, or ELK.
+
+Configuration
+-------------
+
+``fapilog`` is designed for zero-configuration setup but offers extensive customization options. All settings can be configured via environment variables or programmatically.
+
+**Quick Configuration Examples:**
+
+.. code-block:: bash
+
+   # Basic configuration
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout
+   export FAPILOG_JSON_CONSOLE=auto
+
+   # Production configuration
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log,loki://loki:3100
+   export FAPILOG_JSON_CONSOLE=json
+   export FAPILOG_REDACT_PATTERNS=password,token,secret
+
+**Programmatic Configuration:**
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+   from fapilog import configure_logging
+
+   settings = LoggingSettings(
+       level="DEBUG",
+       sinks=["stdout", "file:///var/log/app.log"],
+       redact_patterns=["password", "token"],
+       queue_enabled=True
+   )
+   logger = configure_logging(settings=settings)
+
+.. note::
+   📖 **For complete configuration reference, see** :doc:`config`
+
+Table of Contents
+=================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   config
+   api-reference
+   user-guide
+
+Development Setup
+=================
+
+.. code-block:: bash
+
+   git clone https://github.com/chris-haste/fastapi-logger.git
+   cd fastapi-logger
+   python -m venv .venv && source .venv/bin/activate
+   pip install -e ".[dev]"
+   hatch run test
+
+.. note::
+   **Repository vs Package Name**: This project is developed in the ``fastapi-logger`` repository but published to PyPI as ``fapilog``. The repository name is descriptive of the project's purpose, while the package name is concise and memorable.
+
+.. warning::
+   The test suite enforces a minimum coverage threshold of 85% using ``pytest-cov``. If coverage falls below this threshold, the test run will fail locally and in CI. To see a detailed coverage report, use ``hatch run test-cov`` or inspect the HTML report in ``htmlcov/`` after running tests.
+
+Development Commands
+--------------------
+
+* ``hatch run lint`` - Run Ruff linter
+* ``hatch run typecheck`` - Run MyPy type checker
+* ``hatch run test`` - Run pytest test suite
+* ``hatch run test-cov`` - Run tests with coverage report
+* ``hatch run test-queue-load`` - Run load testing for logging queue
+
+Pre-commit Hooks
+----------------
+
+This project uses pre-commit hooks to ensure code quality. The hooks run automatically on staged files and include:
+
+* **Ruff** - Linting and code formatting
+* **MyPy** - Type checking
+* **Vulture** - Dead code detection
+
+**Setup:**
+
+.. code-block:: bash
+
+   # Install pre-commit (included in dev dependencies)
+   pip install -e ".[dev]"
+
+   # Install the git hooks
+   pre-commit install
+
+   # Run manually on all files
+   pre-commit run --all-files
+
+.. note::
+   The pre-commit hooks will run automatically on staged files when you commit. You can also run them manually using the commands above.
+
+Contributing
+============
+
+We welcome contributions! Please see our `Contributing Guide <https://github.com/chris-haste/fastapi-logger/blob/main/CONTRIBUTING.md>`_ for detailed information on:
+
+* Setting up your development environment
+* Code style and testing guidelines
+* Commit message conventions
+* Pull request process
+* Release procedures
+
+How It Works
+============
+
+.. code-block:: text
+
+   Request ─► TraceIDMiddleware ─► structlog pipeline ─► Async Queue ─► Sink(s)
+                 ▲                                            │
+                 └──────────── contextvars (trace_id, user_id, …)
+                                                 stdout, file, Loki…
+
+**Core Components:**
+
+* **middleware.py** — injects trace/context and measures request duration
+* **enrichers.py** — attaches hostname, memory usage, SQL timings, etc.
+* **_internal/queue.py** — decouples log generation from I/O
+* **sinks/** — pluggable writers (stdout, file, Loki, custom)
+
+**Configuration:** All behavior is configurable via environment variables or programmatic settings. See :doc:`config` for complete reference.
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search` 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# Documentation build dependencies for ReadTheDocs
+sphinx>=5.0.0
+sphinx-rtd-theme>=1.0.0
+myst-parser>=0.18.0
+sphinx-autodoc-typehints>=1.19.0
+
+# Project dependencies needed for autodoc
+structlog
+pydantic>=2.0.0
+pydantic-settings>=2.0.0
+anyio 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -1,0 +1,405 @@
+User Guide
+==========
+
+This guide provides step-by-step tutorials for using ``fapilog`` in your applications. It's designed to take you from basic setup to advanced features, with practical examples throughout.
+
+Table of Contents
+-----------------
+
+* `Quick Start`_
+* `Basic Configuration`_
+* `FastAPI Integration`_
+* `User Context Enrichment`_
+* `Advanced Configuration`_
+* `Custom Enrichers`_
+* `Container Architecture`_
+* `Custom Sinks`_
+* `Performance Tuning`_
+* `Production Deployment`_
+* `Troubleshooting`_
+
+Quick Start
+===========
+
+Get up and running with ``fapilog`` in under 5 minutes.
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install fapilog
+
+Basic Setup
+-----------
+
+The simplest way to get started:
+
+.. code-block:: python
+
+   from fapilog import configure_logging, log
+
+   # Configure logging with defaults
+   configure_logging()
+
+   # Start logging
+   log.info("Application started", version="1.0.0")
+   log.warning("Deprecated feature used", feature="old_api")
+   log.error("Database connection failed", database="postgres")
+
+**What happens:**
+
+- Structured JSON logs are written to stdout
+- Pretty-printed logs in development (TTY detection)
+- Automatic trace ID generation
+- Context variables for request correlation
+
+Basic Configuration
+===================
+
+Environment Variables
+--------------------
+
+The easiest way to configure ``fapilog`` is through environment variables:
+
+.. code-block:: bash
+
+   # Basic configuration
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout
+   export FAPILOG_JSON_CONSOLE=auto
+   
+   # Production configuration
+   export FAPILOG_LEVEL=INFO
+   export FAPILOG_SINKS=stdout,file:///var/log/app.log
+   export FAPILOG_JSON_CONSOLE=json
+   export FAPILOG_REDACT_PATTERNS=password,token,secret
+
+Programmatic Configuration
+-------------------------
+
+For more control, configure programmatically:
+
+.. code-block:: python
+
+   from fapilog.settings import LoggingSettings
+   from fapilog import configure_logging
+
+   settings = LoggingSettings(
+       level="DEBUG",
+       sinks=["stdout", "file:///var/log/app.log"],
+       queue_enabled=True,
+       redact_patterns=["password", "token", "secret"]
+   )
+   
+   configure_logging(settings=settings)
+
+FastAPI Integration
+==================
+
+Zero-Config Setup
+----------------
+
+The simplest FastAPI integration:
+
+.. code-block:: python
+
+   from fastapi import FastAPI
+   from fapilog import configure_logging, log
+
+   app = FastAPI()
+   
+   # This automatically adds TraceIDMiddleware
+   configure_logging(app=app)
+
+   @app.get("/")
+   async def root():
+       log.info("Root endpoint accessed")
+       return {"message": "Hello World"}
+
+**Features provided:**
+
+- Automatic request/response logging
+- Trace ID generation and propagation
+- Request timing and status codes
+- Context enrichment with request details
+
+Manual Middleware Setup
+----------------------
+
+For more control over middleware configuration:
+
+.. code-block:: python
+
+   from fastapi import FastAPI
+   from fapilog import configure_logging
+   from fapilog.middleware import TraceIDMiddleware
+
+   app = FastAPI()
+   
+   # Configure logging first
+   configure_logging()
+   
+   # Add middleware manually with options
+   app.add_middleware(
+       TraceIDMiddleware,
+       trace_header="X-Trace-ID",
+       generate_trace_id=True
+   )
+
+User Context Enrichment
+=======================
+
+Adding User Information
+----------------------
+
+Enrich logs with user context for better debugging:
+
+.. code-block:: python
+
+   from fapilog import log, set_user_context
+   from fastapi import Depends
+
+   async def get_current_user():
+       # Your user authentication logic
+       return {"user_id": "123", "username": "alice"}
+
+   @app.get("/profile")
+   async def get_profile(user=Depends(get_current_user)):
+       # Set user context for all subsequent logs
+       set_user_context(
+           user_id=user["user_id"],
+           username=user["username"]
+       )
+       
+       log.info("Profile accessed")  # Automatically includes user context
+       return {"profile": "data"}
+
+Background Tasks
+---------------
+
+User context is preserved in background tasks:
+
+.. code-block:: python
+
+   from fastapi import BackgroundTasks
+
+   def send_email(email: str):
+       # User context from the request is still available
+       log.info("Sending email", recipient=email)
+       # Email sending logic here
+
+   @app.post("/send-notification")
+   async def send_notification(
+       background_tasks: BackgroundTasks,
+       user=Depends(get_current_user)
+   ):
+       set_user_context(user_id=user["user_id"])
+       background_tasks.add_task(send_email, user["email"])
+       return {"status": "queued"}
+
+Advanced Configuration
+=====================
+
+Multiple Sinks
+--------------
+
+Send logs to multiple destinations:
+
+.. code-block:: python
+
+   settings = LoggingSettings(
+       sinks=[
+           "stdout",  # Console output
+           "file:///var/log/app.log",  # File with rotation
+           "loki://loki:3100"  # Grafana Loki
+       ]
+   )
+
+PII Redaction
+------------
+
+Automatically redact sensitive information:
+
+.. code-block:: python
+
+   settings = LoggingSettings(
+       redact_patterns=["password", "token", "ssn"],
+       redact_fields=["user.email", "request.headers.authorization"],
+       enable_auto_redact_pii=True
+   )
+
+Custom Enrichers
+===============
+
+Creating Custom Enrichers
+-------------------------
+
+Add custom context to all log messages:
+
+.. code-block:: python
+
+   from fapilog.enrichers import BaseEnricher
+
+   class DatabaseEnricher(BaseEnricher):
+       def enrich(self, event_dict):
+           event_dict["db_pool_size"] = get_pool_size()
+           event_dict["db_active_connections"] = get_active_connections()
+           return event_dict
+
+   # Register the enricher
+   settings = LoggingSettings(
+       custom_enrichers=[DatabaseEnricher()]
+   )
+
+Container Architecture
+=====================
+
+For applications with multiple logging configurations:
+
+.. code-block:: python
+
+   from fapilog.container import LoggingContainer
+
+   # Create isolated logging containers
+   api_container = LoggingContainer("api")
+   worker_container = LoggingContainer("worker")
+   
+   # Configure each independently
+   api_logger = api_container.configure(
+       level="INFO",
+       sinks=["stdout", "loki://loki:3100"]
+   )
+   
+   worker_logger = worker_container.configure(
+       level="DEBUG", 
+       sinks=["file:///var/log/worker.log"]
+   )
+
+Custom Sinks
+============
+
+Creating a custom sink for external services:
+
+.. code-block:: python
+
+   from fapilog.sinks import BaseSink
+
+   class SlackSink(BaseSink):
+       def __init__(self, webhook_url: str):
+           self.webhook_url = webhook_url
+           
+       async def emit(self, record):
+           if record["level"] == "error":
+               await self.send_to_slack(record)
+               
+       async def send_to_slack(self, record):
+           # Implementation for Slack webhook
+           pass
+
+Performance Tuning
+==================
+
+Queue Configuration
+------------------
+
+Optimize for high-throughput scenarios:
+
+.. code-block:: python
+
+   settings = LoggingSettings(
+       queue_enabled=True,
+       queue_maxsize=5000,
+       queue_batch_size=100,
+       queue_batch_timeout=1.0,
+       queue_overflow="drop"  # Drop oldest when full
+   )
+
+Sampling
+--------
+
+Reduce log volume in production:
+
+.. code-block:: python
+
+   settings = LoggingSettings(
+       sampling_rate=0.1,  # Log only 10% of messages
+       level="WARNING"     # Only warnings and above
+   )
+
+Production Deployment
+====================
+
+Docker Configuration
+-------------------
+
+.. code-block:: bash
+
+   # Environment variables in docker-compose.yml
+   environment:
+     - FAPILOG_LEVEL=INFO
+     - FAPILOG_SINKS=stdout,loki://loki:3100
+     - FAPILOG_JSON_CONSOLE=json
+     - FAPILOG_REDACT_PATTERNS=password,token,secret
+
+Kubernetes ConfigMap
+-------------------
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: app-logging-config
+   data:
+     FAPILOG_LEVEL: "INFO"
+     FAPILOG_SINKS: "stdout,loki://loki.monitoring.svc.cluster.local:3100"
+     FAPILOG_JSON_CONSOLE: "json"
+     FAPILOG_REDACT_PATTERNS: "password,token,secret"
+
+Troubleshooting
+===============
+
+Common Issues
+------------
+
+**Issue: Logs not appearing**
+
+- Check log level configuration
+- Verify sink configuration
+- Check queue status if enabled
+
+.. code-block:: python
+
+   from fapilog.monitoring import get_queue_metrics
+   
+   metrics = get_queue_metrics()
+   print(f"Queue size: {metrics.current_size}")
+   print(f"Dropped messages: {metrics.dropped_messages}")
+
+**Issue: Performance problems**
+
+- Enable async queue
+- Adjust batch sizes
+- Consider sampling for high-volume scenarios
+
+**Issue: Missing trace IDs**
+
+- Ensure TraceIDMiddleware is properly configured
+- Check that you're within a request context
+- Verify middleware order
+
+Debug Mode
+----------
+
+Enable debug mode for troubleshooting:
+
+.. code-block:: python
+
+   settings = LoggingSettings(
+       level="DEBUG",
+       enable_debug_logging=True
+   )
+
+.. note::
+   For complete tutorials and examples, see the full user guide in the source markdown file: ``docs/user-guide.md`` 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ prometheus = [
 [project.urls]
 Homepage = "https://github.com/chris-haste/fastapi-logger"
 Repository = "https://github.com/chris-haste/fastapi-logger"
-Documentation = "https://github.com/chris-haste/fastapi-logger#readme"
+Documentation = "https://fapilog.readthedocs.io/"
 Bug-Tracker = "https://github.com/chris-haste/fastapi-logger/issues"
 "PyPI Package" = "https://pypi.org/project/fapilog/"
 


### PR DESCRIPTION
- Add .readthedocs.yml configuration for automatic builds
- Add docs/conf.py with Sphinx configuration
- Add docs/requirements.txt with documentation dependencies
- Convert README.md to docs/index.rst as main documentation entry
- Convert docs/config.md to docs/config.rst
- Create simplified docs/api-reference.rst and docs/user-guide.rst
- Update README.md and pyproject.toml with ReadTheDocs links
- Configure Sphinx with sphinx-rtd-theme and autodoc support
- Enable PDF and EPUB generation on ReadTheDocs

Implements Story 14.1: ReadTheDocs Compatibility for hosted documentation