### PR TITLE
feat(docs): implement hybrid documentation update strategy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,93 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'src/**'
+      - 'pyproject.toml'
+      - '.readthedocs.yml'
+  release:
+    types: [ published ]
+
+jobs:
+  deploy-docs:
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+          pip install -e .
+
+      - name: Build documentation
+        run: |
+          cd docs
+          sphinx-build -b html . _build/html
+
+      - name: Validate documentation
+        run: |
+          cd docs
+          # Check for broken links
+          python -m sphinx.ext.linkcheck -b linkcheck _build/html || true
+          
+          # Check for missing references
+          python -m sphinx.ext.intersphinx _build/html || true
+
+      - name: Notify ReadTheDocs
+        run: |
+          echo "Documentation built successfully"
+          echo "ReadTheDocs will automatically rebuild from the repository"
+          echo "Documentation URL: https://fapilog.readthedocs.io/"
+
+  # Optional: Deploy to GitHub Pages as backup
+  deploy-gh-pages:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs: deploy-docs
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+          pip install -e .
+
+      - name: Build documentation
+        run: |
+          cd docs
+          sphinx-build -b html . _build/html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,4 +32,19 @@ search:
   ranking:
     api-reference.html: 1
   ignore:
-    - 404.html 
+    - 404.html
+
+# Version control settings
+# This enables version-specific documentation
+# Users can switch between "latest" and specific versions
+# 
+# ReadTheDocs automatically:
+# - Builds "latest" from main branch (updates on every push)
+# - Builds version-specific docs from release tags (v0.1.0, v0.1.1, etc.)
+# - Provides version switcher in the documentation
+# 
+# URLs:
+# - Latest: https://fapilog.readthedocs.io/
+# - Version-specific: https://fapilog.readthedocs.io/en/v0.1.0/
+# - Version-specific: https://fapilog.readthedocs.io/en/v0.1.1/
+# etc. 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,9 +66,22 @@ python scripts/publish_to_pypi.py
      - Bug fix in A
      ```
 
-3. **Commit the changes**
+3. **Update Documentation** (if needed)
+
+   - Review and update API documentation
+   - Update examples and tutorials
+   - Ensure all new features are documented
+   - Test documentation builds locally:
+
+     ```bash
+     pip install -e ".[docs]"
+     cd docs
+     sphinx-build -b html . _build/html
+     ```
+
+4. **Commit the changes**
    ```bash
-   git add pyproject.toml CHANGELOG.md
+   git add pyproject.toml CHANGELOG.md docs/
    git commit -m "chore(release): vX.Y.Z"
    git push origin main
    ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,13 +9,26 @@
 import os
 import sys
 
+import tomllib
+
 sys.path.insert(0, os.path.abspath("../src"))
+
+
+# Read version from pyproject.toml
+def get_version():
+    try:
+        with open("../pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+            return data["project"]["version"]
+    except Exception:
+        return "0.1.2"  # fallback
+
 
 project = "fapilog"
 copyright = "2024, Chris Haste"
 author = "Chris Haste"
-release = "0.1.2"
-version = "0.1.2"
+release = get_version()
+version = get_version()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ dev = [
     "vulture>=2.10.0",
     "build>=1.0.0",
 ]
+docs = [
+    "sphinx>=5.0.0",
+    "sphinx-rtd-theme>=1.0.0",
+    "myst-parser>=0.18.0",
+    "sphinx-autodoc-typehints>=1.19.0",
+]
 loki = [
     "httpx>=0.27.0",
 ]


### PR DESCRIPTION
- Add automatic version reading from pyproject.toml in Sphinx config
- Create GitHub Actions workflow for documentation deployment
- Add docs optional dependency group to pyproject.toml
- Update release process to include documentation updates
- Enhance ReadTheDocs configuration with version control comments
- Enable both automatic updates and version-specific documentation

This implements a hybrid approach where:
- Documentation updates automatically on every push to main
- Release tags create version-specific documentation
- Users can choose between 'latest' and stable versions