### PR TITLE
docs: add dynamic version information to documentation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,6 +4,8 @@
 
 This reference provides comprehensive documentation for all public functions, classes, and configuration options in Fapilog. Each section includes practical examples, default values, and allowable options.
 
+**Current Version:** {{ version }} | [Changelog](https://github.com/chris-haste/fastapi-logger/blob/main/CHANGELOG.md)
+
 **See also:** [User Guide](user-guide.md), [Quickstart](quickstart.md), [Configuration Guide](config.md)
 
 ---

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,7 +117,15 @@ myst_enable_extensions = [
     "colon_fence",
     "fieldlist",
     "attrs_inline",
+    "substitution",
 ]
+
+# MyST substitutions for version and other variables
+myst_substitutions = {
+    "version": get_version(),
+    "release": get_version(),
+    "current_version": get_version(),
+}
 
 # TODO extension
 todo_include_todos = True

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,6 +2,8 @@
 
 This guide provides a complete reference for all configuration options available in `fapilog`. All settings can be configured via environment variables or programmatically through the `LoggingSettings` class.
 
+**Current Version:** {{ version }} | [Changelog](https://github.com/chris-haste/fastapi-logger/blob/main/CHANGELOG.md)
+
 **See also:** [User Guide](user-guide.md), [API Reference](api-reference.md), [Quickstart](quickstart.md), [Primer](primer.md), [Style Guide](style-guide.md)
 
 ## Quick Start

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 > **Note:** All documentation is written in Markdown (`.md`). Do not add `.rst` files or navigation.
 
+**Current Version:** {{ version }} | [Changelog](https://github.com/chris-haste/fastapi-logger/blob/main/CHANGELOG.md) | [GitHub](https://github.com/chris-haste/fastapi-logger)
+
 Welcome to the Fapilog documentation! This is the canonical entry point for all user and contributor documentation.
 
 ---
@@ -89,8 +91,10 @@ This documentation follows a progressive learning path:
 
 ## Related Resources
 
+- **Current Version**: {{ version }}
 - **GitHub Repository**: [chris-haste/fastapi-logger](https://github.com/chris-haste/fastapi-logger)
 - **PyPI Package**: [fapilog](https://pypi.org/project/fapilog/)
+- **Changelog**: [Release History](https://github.com/chris-haste/fastapi-logger/blob/main/CHANGELOG.md)
 - **Issues & Discussions**: [GitHub Issues](https://github.com/chris-haste/fastapi-logger/issues)
 
 ---


### PR DESCRIPTION
- Add current version display to main documentation pages using MyST substitutions
- Include links to changelog and GitHub repository
- Configure MyST substitutions with {{ version }} syntax for dynamic version replacement
- Add version info to index, config, and API reference pages
- Version automatically updates when pyproject.toml version changes