### PR TITLE
feat: Remove global queue worker and thread-local storage (Issue #90)

### DIFF
--- a/src/fapilog/bootstrap.py
+++ b/src/fapilog/bootstrap.py
@@ -59,11 +59,6 @@ def configure_logging(
         app=app,
     )
 
-    # Update global queue worker for backward compatibility
-    from ._internal.queue import set_queue_worker
-
-    set_queue_worker(container.queue_worker)
-
     return result
 
 


### PR DESCRIPTION
- Remove global queue worker functions (get_queue_worker, set_queue_worker)
- Eliminate thread-local storage for queue management
- Remove global worker variable (_global_queue_worker)
- Update queue_sink() to use container-only approach
- Remove backward compatibility tests
- Update container architecture for direct worker access
- Simplify queue access to single pattern: container.queue_worker

Architecture improvements:
- Eliminated complex global state management
- Removed race condition potential from thread-local storage
- Simplified queue access patterns
- Improved performance and maintainability

QA Review: ✅ Approved - All acceptance criteria met