### PR TITLE
fix: resolve async/sync anti-patterns in sink implementations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,7 +310,8 @@ ignore_names = [
     "reset_request_metadata",
     "reset_response_metadata",
     # Queue and async functions
-    "queue_sink_async",
+    "enqueue",
+    
     "reset_logging",
     # Enricher functions
     "create_user_dependency",

--- a/src/fapilog/_internal/queue_integration.py
+++ b/src/fapilog/_internal/queue_integration.py
@@ -97,27 +97,3 @@ def queue_sink(
             raise structlog.DropEvent
         except asyncio.QueueFull:
             raise structlog.DropEvent from None
-
-
-async def queue_sink_async(
-    logger: Any, method_name: str, event_dict: Dict[str, Any]
-) -> Optional[Dict[str, Any]]:
-    """Async version of queue_sink for use in async contexts."""
-    # Import here to avoid circular import
-    from ..container import get_current_container
-
-    container = get_current_container()
-    if container is None:
-        return event_dict
-
-    worker = getattr(container, "queue_worker", None)
-    if worker is None:
-        return event_dict
-
-    # Try to enqueue the event
-    enqueued = await worker.enqueue(event_dict)
-    if not enqueued:
-        # Queue is full or shutting down, drop the event silently
-        return None
-
-    return None  # Prevent further processing


### PR DESCRIPTION
- Fix FileSink to use asyncio.Lock instead of threading.Lock
- Run file operations in executor to prevent event loop blocking
- Fix mypy type errors in FileSink async implementation
- Add enqueue method to vulture whitelist in pyproject.toml
- Update queue_integration.py to remove dual sync/async patterns
- All pre-commit checks passing (ruff, mypy, vulture)
- All sink tests passing with improved async patterns

Resolves Issue #94: Architecture improvements for async sink implementations