### PR TITLE
feat: Remove global lock manager state and implement container-scoped lock management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![CI](https://github.com/chris-haste/fastapi-logger/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.8+-blue.svg)
-![PyPI](https://img.shields.io/badge/pypi/v/fapilog)
+![PyPI](https://img.shields.io/pypi/v/fapilog)
+![PyPI](https://img.shields.io/pypi/status/fapilog)
 ![Codecov](https://codecov.io/gh/chris-haste/fastapi-logger/graph/badge.svg)
 
 **Production-ready structured logging for FastAPI with trace IDs, async queues, and observability integration.**

--- a/src/fapilog/_internal/async_lock_manager.py
+++ b/src/fapilog/_internal/async_lock_manager.py
@@ -1,8 +1,8 @@
 """Centralized async lock management for processors.
 
-This module provides thread-safe async lock management to eliminate race conditions
-in processor operations. It addresses the mixed threading.Lock/asyncio.Lock patterns
-identified in the current codebase.
+This module provides thread-safe async lock management to eliminate race
+conditions in processor operations. It addresses the mixed
+threading.Lock/asyncio.Lock patterns identified in the current codebase.
 """
 
 import asyncio
@@ -109,23 +109,3 @@ class ProcessorLockManager:
     async def __aexit__(self, _exc_type, _exc_val, _exc_tb):
         """Async context manager exit with cleanup."""
         await self.cleanup_unused_locks()
-
-
-# Global instance for processor use
-_global_lock_manager = None
-_global_lock_manager_lock = threading.Lock()
-
-
-def get_processor_lock_manager() -> ProcessorLockManager:
-    """Get global processor lock manager instance.
-
-    Returns:
-        ProcessorLockManager: Global lock manager instance
-    """
-    global _global_lock_manager
-    if _global_lock_manager is None:
-        with _global_lock_manager_lock:
-            if _global_lock_manager is None:
-                _global_lock_manager = ProcessorLockManager()
-                logger.info("Initialized global ProcessorLockManager")
-    return _global_lock_manager

--- a/src/fapilog/pipeline.py
+++ b/src/fapilog/pipeline.py
@@ -128,22 +128,28 @@ def build_processor_chain(
 
     # 14. Throttling processor - class-based with error handling (if enabled)
     if settings.enable_throttling:
-        throttle_processor = ThrottleProcessor(
-            max_rate=settings.throttle_max_rate,
-            window_seconds=settings.throttle_window_seconds,
-            key_field=settings.throttle_key_field,
-            strategy=settings.throttle_strategy,
-        )
+        throttle_config = {
+            "max_rate": settings.throttle_max_rate,
+            "window_seconds": settings.throttle_window_seconds,
+            "key_field": settings.throttle_key_field,
+            "strategy": settings.throttle_strategy,
+        }
+        if container is not None:
+            throttle_config["container"] = container
+        throttle_processor = ThrottleProcessor(**throttle_config)
         processors.append(_create_safe_processor(throttle_processor))
 
     # 15. Deduplication processor - class-based with error handling (if enabled)
     if settings.enable_deduplication:
-        dedupe_processor = DeduplicationProcessor(
-            window_seconds=settings.dedupe_window_seconds,
-            dedupe_fields=settings.dedupe_fields,
-            max_cache_size=settings.dedupe_max_cache_size,
-            hash_algorithm=settings.dedupe_hash_algorithm,
-        )
+        dedupe_config = {
+            "window_seconds": settings.dedupe_window_seconds,
+            "dedupe_fields": settings.dedupe_fields,
+            "max_cache_size": settings.dedupe_max_cache_size,
+            "hash_algorithm": settings.dedupe_hash_algorithm,
+        }
+        if container is not None:
+            dedupe_config["container"] = container
+        dedupe_processor = DeduplicationProcessor(**dedupe_config)
         processors.append(_create_safe_processor(dedupe_processor))
 
     # 16. Sampling processor - class-based with error handling


### PR DESCRIPTION
- Remove _global_lock_manager and _global_lock_manager_lock global variables
- Remove get_processor_lock_manager() global function from async_lock_manager.py
- Update AsyncProcessorBase to use container-scoped or explicit lock manager
- Update pipeline.py to pass container to AsyncProcessorBase processors
- Add container-scoped lock manager tests and integration validation
- Update performance and async integration tests for new behavior
- Maintain backward compatibility with fallback to new instance creation
- Eliminate global lock bottleneck and enable true container isolation

Fixes #162