### PR TITLE
feat: Extract LifecycleManager from LoggingContainer (#196)

### DIFF
--- a/src/fapilog/_internal/lifecycle_manager.py
+++ b/src/fapilog/_internal/lifecycle_manager.py
@@ -1,0 +1,227 @@
+"""Lifecycle management for fapilog logging components.
+
+This module provides a dedicated LifecycleManager class that handles
+all lifecycle-related operations extracted from LoggingContainer, following
+the single responsibility principle.
+
+Key Features:
+- Standard logging configuration
+- Shutdown handler registration for FastAPI apps
+- Graceful shutdown and cleanup operations
+- Async/await pattern support
+- Thread-safe operations
+- Clean interface with no external dependencies beyond required types
+"""
+
+import atexit
+import logging
+import threading
+from typing import Any, Callable, Optional
+
+from ..middleware import TraceIDMiddleware
+from ..monitoring import PrometheusExporter
+from ..settings import LoggingSettings
+from .error_handling import handle_configuration_error
+
+logger = logging.getLogger(__name__)
+
+
+class LifecycleManager:
+    """Manages lifecycle operations for logging components.
+
+    This class handles all application lifecycle events including startup
+    configuration, shutdown handlers, and graceful cleanup operations.
+
+    Design Principles:
+    - Clean separation of lifecycle concerns
+    - Thread-safe operations
+    - Async/await pattern support for shutdown handlers
+    - Proper resource cleanup and graceful shutdown
+    - No direct dependencies on sinks or middleware logic
+    """
+
+    def __init__(self, container_id: str) -> None:
+        """Initialize the lifecycle manager.
+
+        Args:
+            container_id: Unique identifier for the associated container
+        """
+        self._container_id = container_id
+        self._lock = threading.RLock()
+        self._shutdown_registered = False
+
+    def configure_standard_logging(self, log_level: str) -> None:
+        """Configure standard library logging.
+
+        Sets up a StreamHandler that outputs to stdout with the specified
+        log level, removing any existing handlers to avoid duplicates.
+
+        Args:
+            log_level: Log level string (DEBUG/INFO/WARNING/ERROR/CRITICAL)
+
+        Raises:
+            ConfigurationError: If log_level is invalid
+        """
+        import sys
+
+        try:
+            # Create a handler that outputs to stdout (like PrintLoggerFactory did)
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setLevel(getattr(logging, log_level.upper()))
+            handler.setFormatter(logging.Formatter("%(message)s"))
+
+            # Configure root logger
+            root_logger = logging.getLogger()
+            root_logger.setLevel(getattr(logging, log_level.upper()))
+
+            # Remove existing handlers to avoid duplicates
+            for existing_handler in root_logger.handlers[:]:
+                root_logger.removeHandler(existing_handler)
+
+            # Add our stdout handler
+            root_logger.addHandler(handler)
+
+        except AttributeError as e:
+            raise handle_configuration_error(
+                e,
+                "log_level",
+                log_level,
+                "valid logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL)",
+            ) from e
+
+    def register_middleware(
+        self,
+        app: Any,
+        settings: LoggingSettings,
+        shutdown_callback: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        """Register middleware and shutdown handlers with FastAPI app.
+
+        Args:
+            app: FastAPI application instance
+            settings: LoggingSettings containing trace_id_header configuration
+            shutdown_callback: Optional callback to register as shutdown handler
+        """
+        # Register trace ID middleware
+        app.add_middleware(TraceIDMiddleware, trace_id_header=settings.trace_id_header)
+
+        # Register shutdown event handler if callback provided
+        if shutdown_callback is not None:
+            app.add_event_handler("shutdown", shutdown_callback)
+
+    def register_shutdown_handler(self, cleanup_func: Callable[[], None]) -> None:
+        """Register atexit shutdown handler to ensure cleanup on process exit.
+
+        Args:
+            cleanup_func: Function to call for cleanup on process exit
+        """
+        with self._lock:
+            if not self._shutdown_registered:
+                atexit.register(cleanup_func)
+                self._shutdown_registered = True
+
+    async def shutdown_async(
+        self,
+        registry: Any,
+        queue_worker: Optional[Any] = None,
+        httpx_propagation: Optional[Any] = None,
+        metrics_collector: Optional[Any] = None,
+        sinks: Optional[Any] = None,
+    ) -> None:
+        """Perform graceful async shutdown of logging components.
+
+        Args:
+            registry: ComponentRegistry instance for cleanup
+            queue_worker: Optional QueueWorker to shutdown
+            httpx_propagation: Optional HttpxTracePropagation to cleanup
+            metrics_collector: Optional MetricsCollector to reset
+            sinks: Optional sinks list to clear
+        """
+        with self._lock:
+            # Cleanup component registry
+            try:
+                registry.cleanup()
+            except Exception as e:
+                logger.warning(f"Error during component registry cleanup: {e}")
+
+            # Shutdown Prometheus exporter if it exists in component registry
+            prometheus_exporter = registry.get_component(PrometheusExporter)
+            if prometheus_exporter is not None:
+                try:
+                    await prometheus_exporter.stop()
+                except Exception as e:
+                    logger.warning(f"Error during Prometheus exporter shutdown: {e}")
+
+            # Shutdown queue worker
+            if queue_worker is not None:
+                try:
+                    await queue_worker.shutdown()
+                except Exception as e:
+                    logger.warning(f"Error during queue worker shutdown: {e}")
+
+            # Cleanup httpx propagation
+            if httpx_propagation is not None:
+                try:
+                    httpx_propagation.cleanup()
+                except Exception as e:
+                    logger.warning(f"Error during httpx propagation cleanup: {e}")
+
+            # Clear sinks if provided
+            if sinks is not None:
+                sinks.clear()
+
+    def shutdown_sync(
+        self,
+        registry: Any,
+        queue_worker: Optional[Any] = None,
+        httpx_propagation: Optional[Any] = None,
+        metrics_collector: Optional[Any] = None,
+        sinks: Optional[Any] = None,
+    ) -> None:
+        """Perform graceful sync shutdown of logging components.
+
+        Args:
+            registry: ComponentRegistry instance for cleanup
+            queue_worker: Optional QueueWorker to shutdown
+            httpx_propagation: Optional HttpxTracePropagation to cleanup
+            metrics_collector: Optional MetricsCollector to reset
+            sinks: Optional sinks list to clear
+        """
+        with self._lock:
+            # Cleanup component registry
+            try:
+                registry.cleanup()
+            except Exception as e:
+                logger.warning(f"Error during component registry cleanup: {e}")
+
+            # Shutdown queue worker (sync version)
+            if queue_worker is not None:
+                try:
+                    queue_worker.shutdown_sync()
+                except Exception as e:
+                    logger.warning(f"Error during sync queue worker shutdown: {e}")
+
+            # Cleanup httpx propagation
+            if httpx_propagation is not None:
+                try:
+                    httpx_propagation.cleanup()
+                except Exception as e:
+                    logger.warning(f"Error during httpx propagation cleanup: {e}")
+
+            # Clear sinks if provided
+            if sinks is not None:
+                sinks.clear()
+
+    def cleanup_resources(self, **resources: Any) -> None:  # noqa: vulture
+        """Clean up and reset all provided resources to None.
+
+        This is a utility method for resetting object references during shutdown.
+
+        Args:
+            **resources: Named resources to set to None in the calling context
+        """
+        # Note: This method signature allows callers to pass in resources
+        # they want to reset, but the actual resetting must be done by the caller
+        # since we can't modify their object references from here.
+        # This method serves as documentation of the cleanup interface.
+        pass

--- a/tests/test_container_easy_wins.py
+++ b/tests/test_container_easy_wins.py
@@ -81,16 +81,20 @@ class TestContainerEasyWins:
                 )  # This should trigger validation
 
     def test_log_level_attribute_error_handling(self):
-        """Test AttributeError handling in logging setup (lines 189-190)."""
-        container = LoggingContainer()
+        """Test AttributeError handling in logging setup via LifecycleManager."""
+        from fapilog._internal.lifecycle_manager import LifecycleManager
+
+        manager = LifecycleManager("test")
 
         # Mock logging to raise AttributeError
-        with patch("fapilog.container.logging.getLogger") as mock_get_logger:
+        with patch(
+            "fapilog._internal.lifecycle_manager.logging.getLogger"
+        ) as mock_get_logger:
             mock_logger = mock_get_logger.return_value
             mock_logger.setLevel.side_effect = AttributeError("Invalid level")
 
             with pytest.raises(ConfigurationError) as exc_info:
-                container._configure_standard_logging("INVALID_LEVEL")
+                manager.configure_standard_logging("INVALID_LEVEL")
 
             assert "log_level" in str(exc_info.value)
 

--- a/tests/test_lifecycle_manager.py
+++ b/tests/test_lifecycle_manager.py
@@ -1,0 +1,390 @@
+"""Tests for LifecycleManager class."""
+
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fapilog._internal.lifecycle_manager import LifecycleManager
+from fapilog.exceptions import ConfigurationError
+from fapilog.settings import LoggingSettings
+
+
+class TestLifecycleManager:
+    """Test suite for LifecycleManager class."""
+
+    def test_lifecycle_manager_initialization(self):
+        """Test LifecycleManager initialization."""
+        container_id = "test_container_123"
+        manager = LifecycleManager(container_id)
+
+        assert manager._container_id == container_id
+        assert hasattr(manager, "_lock")
+        assert not manager._shutdown_registered
+
+    def test_configure_standard_logging_info_level(self):
+        """Test configuring standard logging with INFO level."""
+        manager = LifecycleManager("test")
+
+        with patch("logging.getLogger") as mock_get_logger, patch(
+            "logging.StreamHandler"
+        ) as mock_handler_class:
+            mock_handler = MagicMock()
+            mock_handler_class.return_value = mock_handler
+            mock_root_logger = MagicMock()
+            mock_root_logger.handlers = []
+            mock_get_logger.return_value = mock_root_logger
+
+            manager.configure_standard_logging("INFO")
+
+            # Verify handler creation and configuration
+            mock_handler_class.assert_called_once_with(sys.stdout)
+            mock_handler.setLevel.assert_called_once_with(logging.INFO)
+            mock_handler.setFormatter.assert_called_once()
+
+            # Verify root logger configuration
+            mock_root_logger.setLevel.assert_called_once_with(logging.INFO)
+            mock_root_logger.addHandler.assert_called_once_with(mock_handler)
+
+    def test_configure_standard_logging_debug_level(self):
+        """Test configuring standard logging with DEBUG level."""
+        manager = LifecycleManager("test")
+
+        with patch("logging.getLogger") as mock_get_logger, patch(
+            "logging.StreamHandler"
+        ) as mock_handler_class:
+            mock_handler = MagicMock()
+            mock_handler_class.return_value = mock_handler
+            mock_root_logger = MagicMock()
+            mock_root_logger.handlers = []
+            mock_get_logger.return_value = mock_root_logger
+
+            manager.configure_standard_logging("DEBUG")
+
+            # Verify DEBUG level is set
+            mock_handler.setLevel.assert_called_once_with(logging.DEBUG)
+            mock_root_logger.setLevel.assert_called_once_with(logging.DEBUG)
+
+    def test_configure_standard_logging_removes_existing_handlers(self):
+        """Test that existing handlers are removed when configuring."""
+        manager = LifecycleManager("test")
+
+        with patch("logging.getLogger") as mock_get_logger, patch(
+            "logging.StreamHandler"
+        ) as mock_handler_class:
+            # Setup existing handlers
+            existing_handler1 = MagicMock()
+            existing_handler2 = MagicMock()
+            mock_root_logger = MagicMock()
+            mock_root_logger.handlers = [existing_handler1, existing_handler2]
+            mock_get_logger.return_value = mock_root_logger
+
+            mock_handler = MagicMock()
+            mock_handler_class.return_value = mock_handler
+
+            manager.configure_standard_logging("INFO")
+
+            # Verify existing handlers were removed
+            assert mock_root_logger.removeHandler.call_count == 2
+            mock_root_logger.removeHandler.assert_any_call(existing_handler1)
+            mock_root_logger.removeHandler.assert_any_call(existing_handler2)
+
+    def test_configure_standard_logging_invalid_level(self):
+        """Test that invalid log levels raise ConfigurationError."""
+        manager = LifecycleManager("test")
+
+        with pytest.raises(ConfigurationError):
+            manager.configure_standard_logging("INVALID_LEVEL")
+
+    def test_register_middleware_with_shutdown_callback(self):
+        """Test registering middleware with shutdown callback."""
+        manager = LifecycleManager("test")
+        mock_app = MagicMock()
+        settings = LoggingSettings(trace_id_header="X-Custom-Trace")
+        shutdown_callback = MagicMock()
+
+        manager.register_middleware(mock_app, settings, shutdown_callback)
+
+        # Verify middleware registration
+        mock_app.add_middleware.assert_called_once()
+        args, kwargs = mock_app.add_middleware.call_args
+        assert len(args) >= 1
+        assert kwargs.get("trace_id_header") == "X-Custom-Trace"
+
+        # Verify shutdown handler registration
+        mock_app.add_event_handler.assert_called_once_with(
+            "shutdown", shutdown_callback
+        )
+
+    def test_register_middleware_without_shutdown_callback(self):
+        """Test registering middleware without shutdown callback."""
+        manager = LifecycleManager("test")
+        mock_app = MagicMock()
+        settings = LoggingSettings(trace_id_header="X-Request-ID")
+
+        manager.register_middleware(mock_app, settings, None)
+
+        # Verify middleware registration
+        mock_app.add_middleware.assert_called_once()
+
+        # Verify no shutdown handler registration
+        mock_app.add_event_handler.assert_not_called()
+
+    def test_register_shutdown_handler_first_time(self):
+        """Test registering shutdown handler for the first time."""
+        manager = LifecycleManager("test")
+        cleanup_func = MagicMock()
+
+        with patch("atexit.register") as mock_atexit:
+            manager.register_shutdown_handler(cleanup_func)
+
+            mock_atexit.assert_called_once_with(cleanup_func)
+            assert manager._shutdown_registered
+
+    def test_register_shutdown_handler_already_registered(self):
+        """Test that shutdown handler is only registered once."""
+        manager = LifecycleManager("test")
+        cleanup_func1 = MagicMock()
+        cleanup_func2 = MagicMock()
+
+        with patch("atexit.register") as mock_atexit:
+            # First registration
+            manager.register_shutdown_handler(cleanup_func1)
+            assert mock_atexit.call_count == 1
+
+            # Second registration should be ignored
+            manager.register_shutdown_handler(cleanup_func2)
+            assert mock_atexit.call_count == 1  # Still only one call
+
+    @pytest.mark.asyncio
+    async def test_shutdown_async_success(self):
+        """Test successful async shutdown."""
+        manager = LifecycleManager("test")
+
+        # Mock components
+        mock_registry = MagicMock()
+        mock_queue_worker = AsyncMock()
+        mock_httpx_propagation = MagicMock()
+        mock_sinks = MagicMock()
+
+        # Mock prometheus exporter
+        mock_prometheus = AsyncMock()
+        mock_registry.get_component.return_value = mock_prometheus
+
+        await manager.shutdown_async(
+            registry=mock_registry,
+            queue_worker=mock_queue_worker,
+            httpx_propagation=mock_httpx_propagation,
+            sinks=mock_sinks,
+        )
+
+        # Verify cleanup calls
+        mock_registry.cleanup.assert_called_once()
+        mock_prometheus.stop.assert_awaited_once()
+        mock_queue_worker.shutdown.assert_awaited_once()
+        mock_httpx_propagation.cleanup.assert_called_once()
+        mock_sinks.clear.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_async_with_errors(self):
+        """Test async shutdown handles errors gracefully."""
+        manager = LifecycleManager("test")
+
+        # Mock components that raise errors
+        mock_registry = MagicMock()
+        mock_registry.cleanup.side_effect = Exception("Registry cleanup error")
+
+        mock_queue_worker = AsyncMock()
+        mock_queue_worker.shutdown.side_effect = Exception("Queue shutdown error")
+
+        mock_httpx_propagation = MagicMock()
+        mock_httpx_propagation.cleanup.side_effect = Exception("Httpx cleanup error")
+
+        # Mock prometheus exporter with error
+        mock_prometheus = AsyncMock()
+        mock_prometheus.stop.side_effect = Exception("Prometheus stop error")
+        mock_registry.get_component.return_value = mock_prometheus
+
+        # Should not raise exceptions
+        with patch("fapilog._internal.lifecycle_manager.logger") as mock_logger:
+            await manager.shutdown_async(
+                registry=mock_registry,
+                queue_worker=mock_queue_worker,
+                httpx_propagation=mock_httpx_propagation,
+            )
+
+            # Verify warnings were logged
+            assert mock_logger.warning.call_count >= 4
+
+    @pytest.mark.asyncio
+    async def test_shutdown_async_no_prometheus_exporter(self):
+        """Test async shutdown when no Prometheus exporter exists."""
+        manager = LifecycleManager("test")
+
+        mock_registry = MagicMock()
+        mock_registry.get_component.return_value = None  # No prometheus exporter
+
+        await manager.shutdown_async(registry=mock_registry)
+
+        # Should not try to stop non-existent prometheus exporter
+        mock_registry.cleanup.assert_called_once()
+
+    def test_shutdown_sync_success(self):
+        """Test successful sync shutdown."""
+        manager = LifecycleManager("test")
+
+        # Mock components
+        mock_registry = MagicMock()
+        mock_queue_worker = MagicMock()
+        mock_httpx_propagation = MagicMock()
+        mock_sinks = MagicMock()
+
+        manager.shutdown_sync(
+            registry=mock_registry,
+            queue_worker=mock_queue_worker,
+            httpx_propagation=mock_httpx_propagation,
+            sinks=mock_sinks,
+        )
+
+        # Verify cleanup calls
+        mock_registry.cleanup.assert_called_once()
+        mock_queue_worker.shutdown_sync.assert_called_once()
+        mock_httpx_propagation.cleanup.assert_called_once()
+        mock_sinks.clear.assert_called_once()
+
+    def test_shutdown_sync_with_errors(self):
+        """Test sync shutdown handles errors gracefully."""
+        manager = LifecycleManager("test")
+
+        # Mock components that raise errors
+        mock_registry = MagicMock()
+        mock_registry.cleanup.side_effect = Exception("Registry cleanup error")
+
+        mock_queue_worker = MagicMock()
+        mock_queue_worker.shutdown_sync.side_effect = Exception("Queue shutdown error")
+
+        mock_httpx_propagation = MagicMock()
+        mock_httpx_propagation.cleanup.side_effect = Exception("Httpx cleanup error")
+
+        # Should not raise exceptions
+        with patch("fapilog._internal.lifecycle_manager.logger") as mock_logger:
+            manager.shutdown_sync(
+                registry=mock_registry,
+                queue_worker=mock_queue_worker,
+                httpx_propagation=mock_httpx_propagation,
+            )
+
+            # Verify warnings were logged
+            assert mock_logger.warning.call_count >= 3
+
+    def test_cleanup_resources_method_exists(self):
+        """Test that cleanup_resources method exists for interface completeness."""
+        manager = LifecycleManager("test")
+
+        # Method should exist and not raise errors
+        manager.cleanup_resources(some_resource="value", another_resource=None)
+
+    def test_thread_safety_multiple_configurations(self):
+        """Test thread safety of configuration operations."""
+        import threading
+
+        manager = LifecycleManager("test")
+        errors = []
+
+        def configure_logging():
+            try:
+                with patch("logging.getLogger") as mock_get_logger, patch(
+                    "logging.StreamHandler"
+                ):
+                    mock_root_logger = MagicMock()
+                    mock_root_logger.handlers = []
+                    mock_get_logger.return_value = mock_root_logger
+
+                    manager.configure_standard_logging("INFO")
+            except Exception as e:
+                errors.append(e)
+
+        # Run multiple threads
+        threads = []
+        for _ in range(5):
+            thread = threading.Thread(target=configure_logging)
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        assert not errors, f"Thread safety test failed with errors: {errors}"
+
+    def test_container_id_storage(self):
+        """Test that container ID is properly stored and accessible."""
+        container_id = "unique_container_456"
+        manager = LifecycleManager(container_id)
+
+        assert manager._container_id == container_id
+
+    def test_lifecycle_manager_isolation(self):
+        """Test that multiple LifecycleManager instances are isolated."""
+        manager1 = LifecycleManager("container_1")
+        manager2 = LifecycleManager("container_2")
+
+        # Register shutdown handler for manager1 only
+        with patch("atexit.register"):
+            manager1.register_shutdown_handler(lambda: None)
+
+        # Manager2 should still be unregistered
+        assert manager1._shutdown_registered
+        assert not manager2._shutdown_registered
+
+        # Should have different container IDs
+        assert manager1._container_id != manager2._container_id
+
+    def test_middleware_registration_with_custom_settings(self):
+        """Test middleware registration with various settings configurations."""
+        manager = LifecycleManager("test")
+        mock_app = MagicMock()
+
+        # Test with custom trace header
+        settings = LoggingSettings(trace_id_header="X-Custom-Header")
+        manager.register_middleware(mock_app, settings)
+
+        # Verify custom header is used
+        args, kwargs = mock_app.add_middleware.call_args
+        assert kwargs["trace_id_header"] == "X-Custom-Header"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_async_partial_components(self):
+        """Test async shutdown with only some components provided."""
+        manager = LifecycleManager("test")
+
+        mock_registry = MagicMock()
+        mock_registry.get_component.return_value = None
+
+        # Should handle None components gracefully
+        await manager.shutdown_async(
+            registry=mock_registry,
+            queue_worker=None,
+            httpx_propagation=None,
+            sinks=None,
+        )
+
+        # Should still cleanup registry
+        mock_registry.cleanup.assert_called_once()
+
+    def test_shutdown_sync_partial_components(self):
+        """Test sync shutdown with only some components provided."""
+        manager = LifecycleManager("test")
+
+        mock_registry = MagicMock()
+
+        # Should handle None components gracefully
+        manager.shutdown_sync(
+            registry=mock_registry,
+            queue_worker=None,
+            httpx_propagation=None,
+            sinks=None,
+        )
+
+        # Should still cleanup registry
+        mock_registry.cleanup.assert_called_once()


### PR DESCRIPTION
- Create LifecycleManager class in src/fapilog/_internal/lifecycle_manager.py
- Extract configure_standard_logging() method from LoggingContainer
- Extract register_middleware() and shutdown handler registration logic
- Implement async/sync shutdown operations with graceful error handling
- Add comprehensive unit tests with 21 test cases (100% coverage)
- Update LoggingContainer to use LifecycleManager for all lifecycle operations
- Preserve thread-safety and async/await patterns
- Clean separation of lifecycle concerns from configuration and sink logic
- Remove unused imports (atexit, TraceIDMiddleware) from container.py
- Update container tests to work with new LifecycleManager interface
- Fix middleware registration in configure() method when already configured

Resolves #196