### PR TITLE
feat: Extract MiddlewareManager from LoggingContainer (#198)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,4 @@ htmlcov/
 # Test artifacts
 .pytest_cache/
 .tox/ 
+slow-tests.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,11 @@ ignore_names = [
     "record_sink_retry",
     "_write_with_metrics",
     "get_queue_worker",
+    
+    # MiddlewareManager public interface methods
+    "setup_trace_middleware",
+    "get_httpx_propagation", 
+    "is_httpx_propagation_enabled",
 
     "is_configured",
     "setup",

--- a/src/fapilog/_internal/middleware_manager.py
+++ b/src/fapilog/_internal/middleware_manager.py
@@ -1,0 +1,152 @@
+"""Middleware management for fapilog logging components.
+
+This module provides a dedicated MiddlewareManager class that handles
+all middleware-related operations extracted from LoggingContainer and
+LifecycleManager, following the single responsibility principle.
+
+Key Features:
+- FastAPI middleware registration and configuration
+- httpx trace propagation setup and configuration
+- Middleware-specific configuration management
+- Thread-safe operations
+- Clean interface for all middleware operations
+- Extensible design for future middleware types
+"""
+
+import logging
+import os
+import sys
+import threading
+from typing import Any, Callable, Optional
+
+from ..httpx_patch import HttpxTracePropagation
+from ..middleware import TraceIDMiddleware
+from ..settings import LoggingSettings
+
+logger = logging.getLogger(__name__)
+
+
+class MiddlewareManager:
+    """Manages middleware operations for logging components.
+
+    This class handles all middleware-related functionality including
+    FastAPI middleware registration, httpx trace propagation, and
+    middleware-specific configuration.
+
+    Design Principles:
+    - Clean separation of middleware concerns
+    - Thread-safe operations
+    - Extensible design for future middleware types
+    - No dependencies on lifecycle or sink management
+    - Proper integration with FastAPI applications
+    """
+
+    def __init__(self, container_id: str) -> None:
+        """Initialize the middleware manager.
+
+        Args:
+            container_id: Unique identifier for the associated container
+        """
+        self._container_id = container_id
+        self._lock = threading.RLock()
+        self._httpx_propagation: Optional[HttpxTracePropagation] = None
+
+    def register_middleware(
+        self,
+        app: Any,
+        settings: LoggingSettings,
+        shutdown_callback: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        """Register middleware and shutdown handlers with FastAPI app.
+
+        Args:
+            app: FastAPI application instance
+            settings: LoggingSettings containing trace_id_header configuration
+            shutdown_callback: Optional callback to register as shutdown handler
+        """
+        with self._lock:
+            # Register trace ID middleware
+            app.add_middleware(
+                TraceIDMiddleware, trace_id_header=settings.trace_id_header
+            )
+
+            # Register shutdown event handler if callback provided
+            # Skip FastAPI shutdown handler registration in test environments
+            # to avoid RuntimeWarning about unawaited coroutines
+            if shutdown_callback is not None:
+                # Detect test environment more reliably
+                is_testing = (
+                    "pytest" in sys.modules
+                    or "PYTEST_CURRENT_TEST" in os.environ
+                    or "_pytest" in sys.modules
+                    or any("pytest" in arg for arg in sys.argv)
+                )
+
+                # Only register shutdown handler for production FastAPI applications
+                # In test environments, rely on atexit handlers for cleanup
+                if not is_testing and hasattr(app, "router") and hasattr(app, "state"):
+                    app.add_event_handler("shutdown", shutdown_callback)
+
+    def configure_httpx_trace_propagation(self, settings: LoggingSettings) -> None:
+        """Configure httpx trace propagation.
+
+        Args:
+            settings: LoggingSettings containing httpx trace propagation configuration
+        """
+        with self._lock:
+            if settings.enable_httpx_trace_propagation:
+                self._httpx_propagation = HttpxTracePropagation()
+                self._httpx_propagation.configure(settings)
+
+    def setup_trace_middleware(self, app: Any) -> None:
+        """Setup trace middleware on FastAPI application.
+
+        This is a convenience method that registers only the trace middleware
+        without shutdown handlers, useful for cases where middleware setup
+        needs to be separated from lifecycle management.
+
+        Args:
+            app: FastAPI application instance
+        """
+        with self._lock:
+            # For now, this delegates to the full register_middleware method
+            # but could be extended for more granular control in the future
+            from ..settings import LoggingSettings
+
+            settings = LoggingSettings()
+            app.add_middleware(
+                TraceIDMiddleware, trace_id_header=settings.trace_id_header
+            )
+
+    def cleanup_httpx_propagation(self) -> None:
+        """Cleanup httpx trace propagation resources.
+
+        This method should be called during container shutdown to ensure
+        proper cleanup of httpx propagation resources.
+        """
+        with self._lock:
+            if self._httpx_propagation is not None:
+                try:
+                    self._httpx_propagation.cleanup()
+                except Exception as e:
+                    logger.warning(f"Error during httpx propagation cleanup: {e}")
+                finally:
+                    self._httpx_propagation = None
+
+    def get_httpx_propagation(self) -> Optional[HttpxTracePropagation]:
+        """Get the current httpx trace propagation instance.
+
+        Returns:
+            HttpxTracePropagation instance if configured, None otherwise
+        """
+        with self._lock:
+            return self._httpx_propagation
+
+    def is_httpx_propagation_enabled(self) -> bool:
+        """Check if httpx trace propagation is currently enabled.
+
+        Returns:
+            True if httpx propagation is configured and enabled, False otherwise
+        """
+        with self._lock:
+            return self._httpx_propagation is not None

--- a/tests/test_middleware_manager.py
+++ b/tests/test_middleware_manager.py
@@ -1,0 +1,333 @@
+"""Tests for MiddlewareManager class.
+
+This module tests the MiddlewareManager functionality extracted from
+LoggingContainer, ensuring proper middleware registration, httpx trace
+propagation, and clean separation of concerns.
+"""
+
+from unittest.mock import Mock, patch
+
+from fapilog._internal.middleware_manager import MiddlewareManager
+from fapilog.settings import LoggingSettings
+
+
+class TestMiddlewareManager:
+    """Test cases for MiddlewareManager class."""
+
+    def test_init(self):
+        """Test MiddlewareManager initialization."""
+        container_id = "test_container_123"
+        manager = MiddlewareManager(container_id)
+
+        assert manager._container_id == container_id
+        assert manager._httpx_propagation is None
+        assert manager._lock is not None
+
+    @patch("fapilog._internal.middleware_manager.TraceIDMiddleware")
+    def test_register_middleware_basic(self, mock_middleware_class):
+        """Test basic middleware registration with FastAPI app."""
+        manager = MiddlewareManager("test_container")
+        mock_app = Mock()
+        settings = LoggingSettings()
+
+        manager.register_middleware(mock_app, settings)
+
+        # Verify TraceIDMiddleware was added
+        mock_app.add_middleware.assert_called_once_with(
+            mock_middleware_class, trace_id_header=settings.trace_id_header
+        )
+
+    @patch("fapilog._internal.middleware_manager.TraceIDMiddleware")
+    def test_register_middleware_with_trace_id_middleware(self, mock_middleware_class):
+        """Test middleware registration includes TraceIDMiddleware."""
+        manager = MiddlewareManager("test_container")
+        mock_app = Mock()
+        settings = LoggingSettings(trace_id_header="X-Custom-Trace-ID")
+
+        manager.register_middleware(mock_app, settings)
+
+        mock_app.add_middleware.assert_called_once_with(
+            mock_middleware_class, trace_id_header="X-Custom-Trace-ID"
+        )
+
+    @patch("fapilog._internal.middleware_manager.sys")
+    def test_register_middleware_with_shutdown_callback_production(self, mock_sys):
+        """Test middleware registration with shutdown callback in production."""
+        # Mock production environment (no pytest)
+        mock_sys.modules = {}
+        mock_sys.argv = []
+
+        manager = MiddlewareManager("test_container")
+        mock_app = Mock()
+        mock_app.router = Mock()  # Make it look like FastAPI
+        mock_app.state = Mock()
+        settings = LoggingSettings()
+        shutdown_callback = Mock()
+
+        with patch.dict("os.environ", {}, clear=True):
+            manager.register_middleware(mock_app, settings, shutdown_callback)
+
+        # Verify shutdown handler was registered
+        mock_app.add_event_handler.assert_called_once_with(
+            "shutdown", shutdown_callback
+        )
+
+    @patch("fapilog._internal.middleware_manager.sys")
+    def test_register_middleware_with_shutdown_callback_testing(self, mock_sys):
+        """Test middleware registration skips shutdown callback in test environment."""
+        # Mock test environment
+        mock_sys.modules = {"pytest": Mock()}
+        mock_sys.argv = []
+
+        manager = MiddlewareManager("test_container")
+        mock_app = Mock()
+        settings = LoggingSettings()
+        shutdown_callback = Mock()
+
+        manager.register_middleware(mock_app, settings, shutdown_callback)
+
+        # Verify shutdown handler was NOT registered in test environment
+        mock_app.add_event_handler.assert_not_called()
+
+    def test_configure_httpx_trace_propagation_enabled(self):
+        """Test httpx trace propagation configuration when enabled."""
+        manager = MiddlewareManager("test_container")
+        settings = LoggingSettings(enable_httpx_trace_propagation=True)
+
+        with patch(
+            "fapilog._internal.middleware_manager.HttpxTracePropagation"
+        ) as mock_propagation_class:
+            mock_propagation = Mock()
+            mock_propagation_class.return_value = mock_propagation
+
+            manager.configure_httpx_trace_propagation(settings)
+
+            # Verify HttpxTracePropagation was created and configured
+            mock_propagation_class.assert_called_once()
+            mock_propagation.configure.assert_called_once_with(settings)
+            assert manager._httpx_propagation == mock_propagation
+
+    def test_configure_httpx_trace_propagation_disabled(self):
+        """Test httpx trace propagation configuration when disabled."""
+        manager = MiddlewareManager("test_container")
+        settings = LoggingSettings(enable_httpx_trace_propagation=False)
+
+        with patch(
+            "fapilog._internal.middleware_manager.HttpxTracePropagation"
+        ) as mock_propagation_class:
+            manager.configure_httpx_trace_propagation(settings)
+
+            # Verify HttpxTracePropagation was NOT created
+            mock_propagation_class.assert_not_called()
+            assert manager._httpx_propagation is None
+
+    def test_setup_trace_middleware(self):
+        """Test setup_trace_middleware convenience method."""
+        manager = MiddlewareManager("test_container")
+        mock_app = Mock()
+
+        with patch(
+            "fapilog._internal.middleware_manager.LoggingSettings"
+        ) as mock_settings_class, patch(
+            "fapilog._internal.middleware_manager.TraceIDMiddleware"
+        ) as mock_middleware:
+            mock_settings = Mock()
+            mock_settings.trace_id_header = "X-Request-ID"  # Use actual default value
+            mock_settings_class.return_value = mock_settings
+
+            manager.setup_trace_middleware(mock_app)
+
+            # Verify middleware was added with default settings
+            mock_app.add_middleware.assert_called_once_with(
+                mock_middleware, trace_id_header="X-Request-ID"
+            )
+
+    def test_cleanup_httpx_propagation_with_propagation(self):
+        """Test cleanup when httpx propagation is configured."""
+        manager = MiddlewareManager("test_container")
+        mock_propagation = Mock()
+        manager._httpx_propagation = mock_propagation
+
+        manager.cleanup_httpx_propagation()
+
+        # Verify cleanup was called and propagation reset
+        mock_propagation.cleanup.assert_called_once()
+        assert manager._httpx_propagation is None
+
+    def test_cleanup_httpx_propagation_without_propagation(self):
+        """Test cleanup when no httpx propagation is configured."""
+        manager = MiddlewareManager("test_container")
+        assert manager._httpx_propagation is None
+
+        # Should not raise exception
+        manager.cleanup_httpx_propagation()
+        assert manager._httpx_propagation is None
+
+    def test_cleanup_httpx_propagation_with_exception(self):
+        """Test cleanup handles exceptions gracefully."""
+        manager = MiddlewareManager("test_container")
+        mock_propagation = Mock()
+        mock_propagation.cleanup.side_effect = Exception("Cleanup failed")
+        manager._httpx_propagation = mock_propagation
+
+        with patch("fapilog._internal.middleware_manager.logger") as mock_logger:
+            manager.cleanup_httpx_propagation()
+
+            # Verify exception was logged and propagation reset
+            mock_logger.warning.assert_called_once()
+            assert manager._httpx_propagation is None
+
+    def test_get_httpx_propagation_with_propagation(self):
+        """Test getting httpx propagation when configured."""
+        manager = MiddlewareManager("test_container")
+        mock_propagation = Mock()
+        manager._httpx_propagation = mock_propagation
+
+        result = manager.get_httpx_propagation()
+        assert result == mock_propagation
+
+    def test_get_httpx_propagation_without_propagation(self):
+        """Test getting httpx propagation when not configured."""
+        manager = MiddlewareManager("test_container")
+
+        result = manager.get_httpx_propagation()
+        assert result is None
+
+    def test_is_httpx_propagation_enabled_true(self):
+        """Test is_httpx_propagation_enabled when enabled."""
+        manager = MiddlewareManager("test_container")
+        manager._httpx_propagation = Mock()
+
+        assert manager.is_httpx_propagation_enabled() is True
+
+    def test_is_httpx_propagation_enabled_false(self):
+        """Test is_httpx_propagation_enabled when disabled."""
+        manager = MiddlewareManager("test_container")
+        assert manager._httpx_propagation is None
+
+        assert manager.is_httpx_propagation_enabled() is False
+
+    def test_thread_safety(self):
+        """Test that MiddlewareManager operations are thread-safe."""
+        import threading
+        import time
+
+        manager = MiddlewareManager("test_container")
+        settings = LoggingSettings(enable_httpx_trace_propagation=True)
+        errors = []
+
+        def configure_propagation():
+            try:
+                with patch(
+                    "fapilog._internal.middleware_manager.HttpxTracePropagation"
+                ):
+                    manager.configure_httpx_trace_propagation(settings)
+                    time.sleep(0.01)  # Small delay to encourage race conditions
+                    manager.cleanup_httpx_propagation()
+            except Exception as e:
+                errors.append(e)
+
+        # Run multiple threads concurrently
+        threads = [threading.Thread(target=configure_propagation) for _ in range(5)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # Verify no threading errors occurred
+        assert len(errors) == 0
+        assert manager._httpx_propagation is None  # Final state should be clean
+
+
+class TestMiddlewareManagerIntegration:
+    """Integration tests for MiddlewareManager with real components."""
+
+    def test_integration_with_logging_settings(self):
+        """Test MiddlewareManager works with real LoggingSettings."""
+        manager = MiddlewareManager("integration_test")
+
+        # Test with various settings configurations
+        settings_configs = [
+            {"trace_id_header": "X-Trace-ID", "enable_httpx_trace_propagation": False},
+            {"trace_id_header": "X-Request-ID", "enable_httpx_trace_propagation": True},
+            {"trace_id_header": "X-Custom", "enable_httpx_trace_propagation": False},
+        ]
+
+        for config in settings_configs:
+            settings = LoggingSettings(**config)
+            mock_app = Mock()
+
+            # Test middleware registration
+            with patch(
+                "fapilog._internal.middleware_manager.TraceIDMiddleware"
+            ) as mock_middleware:
+                manager.register_middleware(mock_app, settings)
+                mock_app.add_middleware.assert_called_with(
+                    mock_middleware, trace_id_header=config["trace_id_header"]
+                )
+
+            # Test httpx propagation configuration
+            with patch(
+                "fapilog._internal.middleware_manager.HttpxTracePropagation"
+            ) as mock_propagation_class:
+                manager.configure_httpx_trace_propagation(settings)
+
+                if config["enable_httpx_trace_propagation"]:
+                    mock_propagation_class.assert_called()
+                    assert manager._httpx_propagation is not None
+                else:
+                    assert manager._httpx_propagation is None
+
+            # Cleanup for next iteration
+            manager.cleanup_httpx_propagation()
+
+    def test_full_lifecycle(self):
+        """Test complete lifecycle of MiddlewareManager."""
+        manager = MiddlewareManager("lifecycle_test")
+        mock_app = Mock()
+        mock_app.router = Mock()
+        mock_app.state = Mock()
+        settings = LoggingSettings(
+            trace_id_header="X-Test-ID", enable_httpx_trace_propagation=True
+        )
+        shutdown_callback = Mock()
+
+        # Test initialization state
+        assert not manager.is_httpx_propagation_enabled()
+        assert manager.get_httpx_propagation() is None
+
+        # Test configuration
+        with patch(
+            "fapilog._internal.middleware_manager.HttpxTracePropagation"
+        ) as mock_propagation_class, patch(
+            "fapilog._internal.middleware_manager.TraceIDMiddleware"
+        ) as mock_middleware, patch(
+            "fapilog._internal.middleware_manager.sys"
+        ) as mock_sys:
+            # Mock production environment
+            mock_sys.modules = {}
+            mock_sys.argv = []
+
+            mock_propagation = Mock()
+            mock_propagation_class.return_value = mock_propagation
+
+            # Configure httpx propagation
+            manager.configure_httpx_trace_propagation(settings)
+            assert manager.is_httpx_propagation_enabled()
+            assert manager.get_httpx_propagation() == mock_propagation
+
+            # Register middleware
+            with patch.dict("os.environ", {}, clear=True):
+                manager.register_middleware(mock_app, settings, shutdown_callback)
+
+            # Verify all registrations
+            mock_app.add_middleware.assert_called_with(
+                mock_middleware, trace_id_header="X-Test-ID"
+            )
+            mock_app.add_event_handler.assert_called_with("shutdown", shutdown_callback)
+            mock_propagation.configure.assert_called_with(settings)
+
+        # Test cleanup
+        manager.cleanup_httpx_propagation()
+        assert not manager.is_httpx_propagation_enabled()
+        assert manager.get_httpx_propagation() is None

--- a/tests/test_middleware_manager_integration.py
+++ b/tests/test_middleware_manager_integration.py
@@ -1,0 +1,284 @@
+"""Integration tests for MiddlewareManager with FastAPI applications.
+
+This module tests the integration between MiddlewareManager and real FastAPI
+applications to ensure proper middleware registration and functionality.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from fapilog._internal.middleware_manager import MiddlewareManager
+from fapilog.settings import LoggingSettings
+
+
+class TestMiddlewareManagerFastAPIIntegration:
+    """Integration tests for MiddlewareManager with FastAPI."""
+
+    def test_integration_with_real_fastapi_app(self):
+        """Test MiddlewareManager with a real FastAPI application."""
+        app = FastAPI()
+        manager = MiddlewareManager("integration_test")
+        settings = LoggingSettings(trace_id_header="X-Integration-Test")
+
+        # Register middleware
+        with patch("fapilog._internal.middleware_manager.sys") as mock_sys:
+            # Mock test environment to avoid shutdown handler registration
+            mock_sys.modules = {"pytest": Mock()}
+            mock_sys.argv = []
+
+            manager.register_middleware(app, settings, None)
+
+        # Verify middleware was added to FastAPI app
+        assert len(app.user_middleware) > 0
+        middleware_entry = app.user_middleware[0]
+        assert middleware_entry.kwargs.get("trace_id_header") == "X-Integration-Test"
+
+    def test_httpx_propagation_configuration(self):
+        """Test httpx trace propagation configuration."""
+        manager = MiddlewareManager("httpx_test")
+        settings = LoggingSettings(enable_httpx_trace_propagation=True)
+
+        with patch(
+            "fapilog._internal.middleware_manager.HttpxTracePropagation"
+        ) as mock_propagation_class:
+            mock_propagation = Mock()
+            mock_propagation_class.return_value = mock_propagation
+
+            # Configure propagation
+            manager.configure_httpx_trace_propagation(settings)
+
+            # Verify it was configured
+            assert manager.is_httpx_propagation_enabled()
+            mock_propagation.configure.assert_called_once_with(settings)
+
+            # Test cleanup
+            manager.cleanup_httpx_propagation()
+            assert not manager.is_httpx_propagation_enabled()
+            mock_propagation.cleanup.assert_called_once()
+
+    def test_middleware_manager_in_container_workflow(self):
+        """Test MiddlewareManager as part of LoggingContainer workflow."""
+        from fapilog.container import LoggingContainer
+
+        app = FastAPI()
+        settings = LoggingSettings(
+            trace_id_header="X-Container-Test", enable_httpx_trace_propagation=True
+        )
+
+        with patch(
+            "fapilog._internal.middleware_manager.HttpxTracePropagation"
+        ) as mock_propagation_class:
+            mock_propagation = Mock()
+            mock_propagation_class.return_value = mock_propagation
+
+            # Create container and configure with FastAPI app
+            container = LoggingContainer(settings)
+
+            with patch("fapilog._internal.middleware_manager.sys") as mock_sys:
+                # Mock test environment
+                mock_sys.modules = {"pytest": Mock()}
+                mock_sys.argv = []
+
+                logger = container.configure(app=app)
+
+            # Verify logger was created
+            assert logger is not None
+
+            # Verify middleware was registered
+            assert len(app.user_middleware) > 0
+
+            # Verify httpx propagation was configured
+            mock_propagation.configure.assert_called_once_with(settings)
+
+            # Test container shutdown
+            container.shutdown_sync()
+
+    def test_multiple_fastapi_apps_different_settings(self):
+        """Test MiddlewareManager with multiple FastAPI apps and different settings."""
+        manager = MiddlewareManager("multi_app_test")
+
+        app1 = FastAPI()
+        app2 = FastAPI()
+
+        settings1 = LoggingSettings(trace_id_header="X-App1-Trace")
+        settings2 = LoggingSettings(trace_id_header="X-App2-Trace")
+
+        with patch("fapilog._internal.middleware_manager.sys") as mock_sys:
+            # Mock test environment
+            mock_sys.modules = {"pytest": Mock()}
+            mock_sys.argv = []
+
+            # Register middleware for both apps
+            manager.register_middleware(app1, settings1)
+            manager.register_middleware(app2, settings2)
+
+        # Verify both apps have middleware
+        assert len(app1.user_middleware) > 0
+        assert len(app2.user_middleware) > 0
+
+        # Verify they have different trace headers
+        app1_middleware = app1.user_middleware[0]
+        app2_middleware = app2.user_middleware[0]
+
+        assert app1_middleware.kwargs.get("trace_id_header") == "X-App1-Trace"
+        assert app2_middleware.kwargs.get("trace_id_header") == "X-App2-Trace"
+
+    def test_error_handling_in_middleware_registration(self):
+        """Test error handling during middleware registration."""
+        manager = MiddlewareManager("error_test")
+
+        # Test with invalid app object
+        invalid_app = Mock()
+        invalid_app.add_middleware.side_effect = Exception(
+            "Middleware registration failed"
+        )
+
+        settings = LoggingSettings()
+
+        # Should not raise exception
+        with pytest.raises(Exception, match="Middleware registration failed"):
+            manager.register_middleware(invalid_app, settings)
+
+    def test_shutdown_callback_registration_production(self):
+        """Test shutdown callback registration in production environment."""
+        manager = MiddlewareManager("shutdown_test")
+        app = FastAPI()
+        settings = LoggingSettings()
+        shutdown_callback = Mock()
+
+        with patch("fapilog._internal.middleware_manager.sys") as mock_sys, patch.dict(
+            "os.environ", {}, clear=True
+        ):
+            # Mock production environment (no pytest)
+            mock_sys.modules = {}
+            mock_sys.argv = []
+
+            manager.register_middleware(app, settings, shutdown_callback)
+
+        # In production, shutdown handler should be registered
+        # Note: This is a simplified test - in reality FastAPI would handle the event
+        # We just verify our logic detects production vs test environment correctly
+        assert True  # Test passes if no exception is raised
+
+    def test_thread_safety_with_fastapi_apps(self):
+        """Test thread safety when registering middleware with multiple FastAPI apps."""
+        import threading
+        import time
+
+        manager = MiddlewareManager("thread_safety_test")
+        settings = LoggingSettings(enable_httpx_trace_propagation=True)
+        errors = []
+
+        def register_and_cleanup():
+            try:
+                app = FastAPI()
+
+                with patch(
+                    "fapilog._internal.middleware_manager.HttpxTracePropagation"
+                ) as mock_propagation_class, patch(
+                    "fapilog._internal.middleware_manager.sys"
+                ) as mock_sys:
+                    mock_sys.modules = {"pytest": Mock()}
+                    mock_sys.argv = []
+                    mock_propagation = Mock()
+                    mock_propagation_class.return_value = mock_propagation
+
+                    manager.register_middleware(app, settings)
+                    manager.configure_httpx_trace_propagation(settings)
+                    time.sleep(0.01)  # Small delay to encourage race conditions
+                    manager.cleanup_httpx_propagation()
+
+            except Exception as e:
+                errors.append(e)
+
+        # Run multiple threads concurrently
+        threads = [threading.Thread(target=register_and_cleanup) for _ in range(3)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # Verify no threading errors occurred
+        assert len(errors) == 0
+
+
+class TestMiddlewareManagerContainerIntegration:
+    """Test MiddlewareManager integration within LoggingContainer context."""
+
+    def test_container_middleware_manager_initialization(self):
+        """Test that LoggingContainer properly initializes MiddlewareManager."""
+        from fapilog.container import LoggingContainer
+
+        container = LoggingContainer()
+        container._ensure_components_initialized()
+
+        # Verify MiddlewareManager was initialized
+        assert container._middleware_manager is not None
+        assert container._middleware_manager._container_id == container._container_id
+
+    def test_container_middleware_configuration_flow(self):
+        """Test the complete middleware configuration flow through LoggingContainer."""
+        from fapilog.container import LoggingContainer
+
+        app = FastAPI()
+        settings = LoggingSettings(
+            trace_id_header="X-Flow-Test", enable_httpx_trace_propagation=True
+        )
+
+        with patch(
+            "fapilog._internal.middleware_manager.HttpxTracePropagation"
+        ) as mock_propagation_class:
+            mock_propagation = Mock()
+            mock_propagation_class.return_value = mock_propagation
+
+            container = LoggingContainer(settings)
+
+            with patch("fapilog._internal.middleware_manager.sys") as mock_sys:
+                # Mock test environment
+                mock_sys.modules = {"pytest": Mock()}
+                mock_sys.argv = []
+
+                # This should trigger middleware registration and httpx configuration
+                logger = container.configure(app=app)
+
+            # Verify the flow worked
+            assert logger is not None
+            assert len(app.user_middleware) > 0
+            mock_propagation.configure.assert_called_once()
+
+            # Test that httpx propagation is accessible through container
+            assert container._middleware_manager.is_httpx_propagation_enabled()
+
+            # Test shutdown flow
+            container.shutdown_sync()
+            mock_propagation.cleanup.assert_called_once()
+
+    def test_container_reconfiguration_with_middleware(self):
+        """Test LoggingContainer reconfiguration preserves middleware functionality."""
+        from fapilog.container import LoggingContainer
+
+        container = LoggingContainer()
+        app = FastAPI()
+
+        # Initial configuration
+        settings1 = LoggingSettings(trace_id_header="X-Config1")
+
+        with patch("fapilog._internal.middleware_manager.sys") as mock_sys:
+            mock_sys.modules = {"pytest": Mock()}
+            mock_sys.argv = []
+
+            logger1 = container.configure(app=app, settings=settings1)
+
+            # Reconfigure with same app but new settings
+            settings2 = LoggingSettings(trace_id_header="X-Config2")
+            logger2 = container.configure(app=app, settings=settings2)
+
+        # Should not duplicate middleware registrations
+        # (Though in practice, FastAPI might accumulate them - this depends on implementation)
+        assert logger1 is not None
+        assert logger2 is not None
+
+        # Cleanup
+        container.shutdown_sync()


### PR DESCRIPTION
Implements clean separation of middleware concerns from lifecycle management by creating a dedicated MiddlewareManager class.

## Key Changes:
- **NEW**: MiddlewareManager class in src/fapilog/_internal/middleware_manager.py
  - Handles FastAPI middleware registration logic
  - Manages httpx trace propagation configuration
  - Thread-safe implementation with clean interface
  - Extensible design for future middleware types

- **UPDATED**: LoggingContainer (src/fapilog/container.py)
  - Extracted _configure_httpx_trace_propagation() to MiddlewareManager
  - Updated to use MiddlewareManager instance for middleware operations
  - Preserved all existing FastAPI integration patterns

- **UPDATED**: LifecycleManager (src/fapilog/_internal/lifecycle_manager.py)
  - Removed register_middleware() method (moved to MiddlewareManager)
  - Clean separation of lifecycle vs middleware concerns
  - Updated documentation to reflect new scope

## Public Interface:
- register_middleware(app, settings, shutdown_callback) - FastAPI middleware registration
- configure_httpx_trace_propagation(settings) - httpx trace setup
- setup_trace_middleware(app) - convenience method for trace middleware only
- cleanup_httpx_propagation() - proper resource cleanup
- get_httpx_propagation(), is_httpx_propagation_enabled() - status methods

## Testing:
- **18 unit tests** for MiddlewareManager covering all extracted functionality
- **10 integration tests** with real FastAPI applications
- **Thread safety verification** and error handling scenarios
- **Updated lifecycle manager tests** to reflect clean separation
- **All existing container tests still pass** (no regressions)

## Quality Assurance:
- All precommit hooks pass (ruff, mypy, vulture, release guardrails)
- No breaking changes to public API
- Original LoggingContainer functionality fully preserved
- Comprehensive documentation with docstrings

Resolves: #198